### PR TITLE
remove  redundant  move

### DIFF
--- a/source/common/tcp/conn_pool_impl.h
+++ b/source/common/tcp/conn_pool_impl.h
@@ -43,7 +43,7 @@ public:
         Network::ReadFilterSharedPtr{new UpstreamReadFilter(*client)});
     client->connection_->connect();
     client->connection_->noDelay(true);
-    return std::move(client);
+    return client;
   }
 
   ~ClientImpl() {


### PR DESCRIPTION
this causes compilation in gcc fail