### PR TITLE
Clustermeta transformation

### DIFF
--- a/changelog/v1.4.0/cluster-metadata-transformation-filter.yaml
+++ b/changelog/v1.4.0/cluster-metadata-transformation-filter.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NEW_FEATURE
+  description: add new command to transformation filter to grab values in the cluster metadata.
+  issueLink: https://github.com/solo-io/gloo/issues/2552
+  resolvesIssue: false

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -101,7 +101,7 @@ TransformerInstance::TransformerInstance(
     const Http::HeaderMap &header_map, GetBodyFunc& body,
     const std::unordered_map<std::string, absl::string_view>& extractions,
     const json &context, const std::unordered_map<std::string, std::string>& environ,
-    const envoy::api::v2::core::Metadata* cluster_metadata)
+    const envoy::config::core::v3::Metadata* cluster_metadata)
     : header_map_(header_map), body_(body), extractions_(extractions),
       context_(context), environ_(environ), cluster_metadata_(cluster_metadata) {
   env_.add_callback("header", 1,
@@ -149,7 +149,7 @@ json TransformerInstance::cluster_metadata_callback(const inja::Arguments& args)
     return "";
   }
 
-  const ProtobufWkt::Value& value = Envoy::Config::Metadata::metadataValue(*cluster_metadata_, "io.solo.transformation", key);
+  const ProtobufWkt::Value& value = Envoy::Config::Metadata::metadataValue(cluster_metadata_, SoloHttpFilterNames::get().Transformation, key);
 
   switch (value.kind_case()) {
   case ProtobufWkt::Value::kStringValue: {
@@ -360,7 +360,7 @@ void InjaTransformer::transform(Http::HeaderMap &header_map,
   }
 
   // get cluster metadata
-  const envoy::api::v2::core::Metadata* cluster_metadata{};
+  const envoy::config::core::v3::Metadata* cluster_metadata{};
   Upstream::ClusterInfoConstSharedPtr ci = callbacks.clusterInfo();
   if (ci.get()) {
     cluster_metadata = &ci.get()->metadata();

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -363,7 +363,7 @@ void InjaTransformer::transform(Http::HeaderMap &header_map,
   const envoy::config::core::v3::Metadata* cluster_metadata{};
   Upstream::ClusterInfoConstSharedPtr ci = callbacks.clusterInfo();
   if (ci.get()) {
-    cluster_metadata = &ci.get()->metadata();
+    cluster_metadata = &ci->metadata();
   }
 
   // start transforming!

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -26,8 +26,8 @@ public:
   TransformerInstance(
       const Http::HeaderMap &header_map, GetBodyFunc& body,
       const std::unordered_map<std::string, absl::string_view> &extractions,
-      const nlohmann::json &context, const std::unordered_map<std::string, std::string>& environ);
-  
+      const nlohmann::json &context, const std::unordered_map<std::string, std::string>& environ,
+      const std::unordered_map<std::string, absl::string_view> &cluster_metadata);
 
   std::string render(const inja::Template &input);
 
@@ -38,6 +38,7 @@ private:
   nlohmann::json extracted_callback(const inja::Arguments& args) const;
   nlohmann::json dynamic_metadata(const inja::Arguments& args) const;
   nlohmann::json env(const inja::Arguments& args) const;
+  nlohmann::json cluster_metadata_callback(const inja::Arguments& args) const;
 
   inja::Environment env_;
   const Http::HeaderMap &header_map_;
@@ -45,6 +46,7 @@ private:
   const std::unordered_map<std::string, absl::string_view> &extractions_;
   const nlohmann::json &context_;
   const std::unordered_map<std::string, std::string>& environ_;
+  const std::unordered_map<std::string, absl::string_view> cluster_metadata_;
 };
 
 class Extractor : Logger::Loggable<Logger::Id::filter> {

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -25,14 +25,14 @@ class TransformerInstance {
 public:
   TransformerInstance(
       const Http::HeaderMap &header_map, GetBodyFunc& body,
-      const std::unordered_map<std::string, absl::string_view> &extractions,
+      const std::unordered_map<std::string, absl::string_view>& extractions,
       const nlohmann::json &context, const std::unordered_map<std::string, std::string>& environ,
-      const std::unordered_map<std::string, absl::string_view> &cluster_metadata);
+      const envoy::api::v2::core::Metadata* cluster_metadata);
 
   std::string render(const inja::Template &input);
 
 private:
-// header_value(name)
+  // header_value(name)
   nlohmann::json header_callback(const inja::Arguments& args) const;
   // extracted_value(name, index)
   nlohmann::json extracted_callback(const inja::Arguments& args) const;
@@ -46,7 +46,7 @@ private:
   const std::unordered_map<std::string, absl::string_view> &extractions_;
   const nlohmann::json &context_;
   const std::unordered_map<std::string, std::string>& environ_;
-  const std::unordered_map<std::string, absl::string_view> cluster_metadata_;
+  const envoy::api::v2::core::Metadata* cluster_metadata_;
 };
 
 class Extractor : Logger::Loggable<Logger::Id::filter> {

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -27,7 +27,7 @@ public:
       const Http::HeaderMap &header_map, GetBodyFunc& body,
       const std::unordered_map<std::string, absl::string_view>& extractions,
       const nlohmann::json &context, const std::unordered_map<std::string, std::string>& environ,
-      const envoy::api::v2::core::Metadata* cluster_metadata);
+      const envoy::config::core::v3::Metadata* cluster_metadata);
 
   std::string render(const inja::Template &input);
 
@@ -46,7 +46,7 @@ private:
   const std::unordered_map<std::string, absl::string_view> &extractions_;
   const nlohmann::json &context_;
   const std::unordered_map<std::string, std::string>& environ_;
-  const envoy::api::v2::core::Metadata* cluster_metadata_;
+  const envoy::config::core::v3::Metadata* cluster_metadata_;
 };
 
 class Extractor : Logger::Loggable<Logger::Id::filter> {

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -619,7 +619,7 @@ TEST(InjaTransformer, ParseFromClusterMetadata) {
   EXPECT_EQ(body.toString(), "val");
 }
 
-TEST(InjaTransformer, ParseFromNilClusterMetadata) {
+TEST(InjaTransformer, ParseFromNilClusterInfo) {
   Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
   TransformationTemplate transformation;
   transformation.mutable_body()->set_text("{{clusterMetadata(\"key\")}}");
@@ -627,9 +627,6 @@ TEST(InjaTransformer, ParseFromNilClusterMetadata) {
   InjaTransformer transformer(transformation);
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
-  envoy::config::core::v3::Metadata* meta{};
-
-  ON_CALL(*callbacks.cluster_info_, metadata()).WillByDefault(testing::ReturnRef(*meta));
 
   Buffer::OwnedImpl body("1");
   transformer.transform(headers, body, callbacks);

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -610,16 +610,10 @@ TEST(InjaTransformer, ParseFromClusterMetadata) {
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
   
-  Upstream::MockClusterInfo* cluster_info = new NiceMock<Upstream::MockClusterInfo>();
-  Upstream::ClusterInfoConstSharedPtr cluster_info_ptr{cluster_info};
-
   envoy::config::core::v3::Metadata meta;
   meta.mutable_filter_metadata()->insert({SoloHttpFilterNames::get().Transformation, MessageUtil::keyValueStruct("key", "val")});
-  ON_CALL(*cluster_info, metadata()).WillByDefault(testing::ReturnRefOfCopy(meta));
+  ON_CALL(*callbacks.cluster_info_, metadata()).WillByDefault(testing::ReturnRefOfCopy(meta));
 
-  EXPECT_CALL(callbacks, clusterInfo())
-      .Times(1)
-      .WillRepeatedly(Return(cluster_info_ptr));
   Buffer::OwnedImpl body("1");
   transformer.transform(headers, body, callbacks);
   EXPECT_EQ(body.toString(), "val");

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -162,10 +162,10 @@ TEST(TransformerInstance, ClusterMetadata) {
   
   std::unordered_map<std::string, std::string> env;
 
-  envoy::config::core::v3::Metadata* cluster_metadata{new envoy::config::core::v3::Metadata};
-  cluster_metadata->mutable_filter_metadata()->insert({SoloHttpFilterNames::get().Transformation, MessageUtil::keyValueStruct("io.solo.hostname", "foo.example.com")});
+  envoy::config::core::v3::Metadata cluster_metadata{};
+  cluster_metadata.mutable_filter_metadata()->insert({SoloHttpFilterNames::get().Transformation, MessageUtil::keyValueStruct("io.solo.hostname", "foo.example.com")});
 
-  TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
+  TransformerInstance t(headers, empty_body, extractions, originalbody, env, &cluster_metadata);
 
   auto res = t.render(parse("{{clusterMetadata(\"io.solo.hostname\")}}"));
   EXPECT_EQ("foo.example.com", res);

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -162,7 +162,7 @@ TEST(TransformerInstance, ClusterMetadata) {
   
   std::unordered_map<std::string, std::string> env;
 
-  envoy::config::core::v3::Metadata cluster_metadata{};
+  envoy::config::core::v3::Metadata cluster_metadata;
   cluster_metadata.mutable_filter_metadata()->insert({SoloHttpFilterNames::get().Transformation, MessageUtil::keyValueStruct("io.solo.hostname", "foo.example.com")});
 
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, &cluster_metadata);

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -627,6 +627,8 @@ TEST(InjaTransformer, ParseFromNilClusterInfo) {
   InjaTransformer transformer(transformation);
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  callbacks.cluster_info_.reset();
+  callbacks.cluster_info_ = nullptr;
 
   Buffer::OwnedImpl body("1");
   transformer.transform(headers, body, callbacks);

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -50,7 +50,7 @@ TEST(TransformerInstance, ReplacesValueFromContext) {
   Http::TestHeaderMapImpl headers;
   std::unordered_map<std::string, absl::string_view> extractions;
   std::unordered_map<std::string, std::string> env;
-  envoy::api::v2::core::Metadata* cluster_metadata{};
+  envoy::config::core::v3::Metadata* cluster_metadata{};
   
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
 
@@ -69,7 +69,7 @@ TEST(TransformerInstance, ReplacesValueFromInlineHeader) {
     };
   std::unordered_map<std::string, absl::string_view> extractions;
   std::unordered_map<std::string, std::string> env;
-  envoy::api::v2::core::Metadata* cluster_metadata{};
+  envoy::config::core::v3::Metadata* cluster_metadata{};
 
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
 
@@ -88,7 +88,7 @@ TEST(TransformerInstance, ReplacesValueFromCustomHeader) {
                                   {"x-custom-header", header}};
   std::unordered_map<std::string, absl::string_view> extractions;
   std::unordered_map<std::string, std::string> env;
-  envoy::api::v2::core::Metadata* cluster_metadata{};
+  envoy::config::core::v3::Metadata* cluster_metadata{};
                                   
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
 
@@ -104,7 +104,7 @@ TEST(TransformerInstance, ReplaceFromExtracted) {
   extractions["f"] = field;
   Http::TestHeaderMapImpl headers;
   std::unordered_map<std::string, std::string> env;
-  envoy::api::v2::core::Metadata* cluster_metadata{};
+  envoy::config::core::v3::Metadata* cluster_metadata{};
   
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
 
@@ -119,7 +119,7 @@ TEST(TransformerInstance, ReplaceFromNonExistentExtraction) {
   extractions["foo"] = absl::string_view("bar");
   Http::TestHeaderMapImpl headers;
   std::unordered_map<std::string, std::string> env;
-  envoy::api::v2::core::Metadata* cluster_metadata{};
+  envoy::config::core::v3::Metadata* cluster_metadata{};
   
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
 
@@ -133,7 +133,7 @@ TEST(TransformerInstance, Environment) {
   std::unordered_map<std::string, absl::string_view> extractions;
   Http::TestHeaderMapImpl headers;
   std::unordered_map<std::string, std::string> env;
-  envoy::api::v2::core::Metadata* cluster_metadata{};
+  envoy::config::core::v3::Metadata* cluster_metadata{};
   env["FOO"] = "BAR";
   
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
@@ -148,7 +148,7 @@ TEST(TransformerInstance, EmptyEnvironment) {
   Http::TestHeaderMapImpl headers;
   
   std::unordered_map<std::string, std::string> env;
-  envoy::api::v2::core::Metadata* cluster_metadata{};
+  envoy::config::core::v3::Metadata* cluster_metadata{};
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
 
   auto res = t.render(parse("{{env(\"FOO\")}}"));
@@ -162,7 +162,7 @@ TEST(TransformerInstance, ClusterMetadata) {
   
   std::unordered_map<std::string, std::string> env;
 
-  envoy::api::v2::core::Metadata* cluster_metadata{new envoy::api::v2::core::Metadata};
+  envoy::config::core::v3::Metadata* cluster_metadata{new envoy::config::core::v3::Metadata};
   cluster_metadata->mutable_filter_metadata()->insert({SoloHttpFilterNames::get().Transformation, MessageUtil::keyValueStruct("io.solo.hostname", "foo.example.com")});
 
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
@@ -177,7 +177,7 @@ TEST(TransformerInstance, EmptyClusterMetadata) {
   Http::TestHeaderMapImpl headers;
 
   std::unordered_map<std::string, std::string> env;
-  envoy::api::v2::core::Metadata* cluster_metadata{};
+  envoy::config::core::v3::Metadata* cluster_metadata{};
 
   TransformerInstance t(headers, empty_body, extractions, originalbody, env, cluster_metadata);
 
@@ -613,7 +613,7 @@ TEST(InjaTransformer, ParseFromClusterMetadata) {
   Upstream::MockClusterInfo* cluster_info = new NiceMock<Upstream::MockClusterInfo>();
   Upstream::ClusterInfoConstSharedPtr cluster_info_ptr{cluster_info};
 
-  envoy::api::v2::core::Metadata meta;
+  envoy::config::core::v3::Metadata meta;
   meta.mutable_filter_metadata()->insert({SoloHttpFilterNames::get().Transformation, MessageUtil::keyValueStruct("key", "val")});
   ON_CALL(*cluster_info, metadata()).WillByDefault(testing::ReturnRefOfCopy(meta));
 

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -619,6 +619,23 @@ TEST(InjaTransformer, ParseFromClusterMetadata) {
   EXPECT_EQ(body.toString(), "val");
 }
 
+TEST(InjaTransformer, ParseFromNilClusterMetadata) {
+  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
+  TransformationTemplate transformation;
+  transformation.mutable_body()->set_text("{{clusterMetadata(\"key\")}}");
+
+  InjaTransformer transformer(transformation);
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  envoy::config::core::v3::Metadata* meta{};
+
+  ON_CALL(*callbacks.cluster_info_, metadata()).WillByDefault(testing::ReturnRef(*meta));
+
+  Buffer::OwnedImpl body("1");
+  transformer.transform(headers, body, callbacks);
+  EXPECT_EQ(body.toString(), "");
+}
+
 } // namespace Transformation
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
add new command to transformation filter to grab values in the cluster metadata.

Sample cluster metadata:
```
"metadata": {
  "filter_metadata": {
    "io.solo.transformation": {
      "host": "foo.example.com"
     }
  }
}
```

transformation filter usage:
`"{{clusterMetadata("host")}}"`
would result in:
`"foo.example.com"`