### PR TITLE
[WIP] Allow duplicate header values

### DIFF
--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -174,6 +174,19 @@ message TransformationTemplate {
   // resulting header, the rendered template will determine the value.
   map<string, InjaTemplate> headers = 3;
 
+  // Defines a header-template pair to be used in `headers_to_append`
+  message HeaderToAppend {
+    // Header name
+    string key = 1;
+    // Apply a template to the header value
+    InjaTemplate value = 2;
+  }
+
+  // Use this attribute to transform request/response headers. It consists of 
+  // an array of string/template objects. Use this attribute to define multiple 
+  // templates for a single header.
+  repeated HeaderToAppend headers_to_append = 10;
+
   // Determines the type of transformation to apply to the request/response body
   oneof body_transformation {
     // Apply a template to the body

--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -171,7 +171,11 @@ message TransformationTemplate {
 
   // Use this attribute to transform request/response headers. It consists of a
   // map of strings to templates. The string key determines the name of the
-  // resulting header, the rendered template will determine the value.
+  // resulting header, the rendered template will determine the value. Any existing
+  // headers with the same header name will be replaced by the transformed header.
+  // If a header name is included in `headers` and `headers_to_append`, it will first
+  // be replaced the template in `headers`, then additional header values will be appended
+  // by the templates defined in `headers_to_append`.
   map<string, InjaTemplate> headers = 3;
 
   // Defines a header-template pair to be used in `headers_to_append`
@@ -184,7 +188,8 @@ message TransformationTemplate {
 
   // Use this attribute to transform request/response headers. It consists of 
   // an array of string/template objects. Use this attribute to define multiple 
-  // templates for a single header.
+  // templates for a single header. Header template(s) defined here will be appended to any 
+  // existing headers with the same header name, not replace existing ones.
   repeated HeaderToAppend headers_to_append = 10;
 
   // Determines the type of transformation to apply to the request/response body

--- a/changelog/v1.17.0-rc3/allow-duplicate-headers.yaml
+++ b/changelog/v1.17.0-rc3/allow-duplicate-headers.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3901
+    resolvesIssue: false
+    description: >
+      Previously, the transformation filter removed multiple headers with the same header name from being processed. 
+      This adds a new field headers_to_append, which allows users to specify multiple template values for a header, and each of the headers values will be present in the final request.

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -93,6 +93,7 @@ private:
   bool passthrough_body_{};
   std::vector<std::pair<std::string, Extractor>> extractors_;
   std::vector<std::pair<Http::LowerCaseString, inja::Template>> headers_;
+  std::vector<std::pair<Http::LowerCaseString, inja::Template>> headers_to_append_;
   std::vector<DynamicMetadataValue> dynamic_metadata_;
   std::unordered_map<std::string, std::string> environ_;
 

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -337,7 +337,7 @@ TEST(Transformer, transformSimple) {
 TEST(Transformer, transformMultipleHeaderValues) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                          {":authority", "www.solo.io"},
-                                         {"x-test", "789"},
+                                         {"x-custom-header", "original value"},
                                          {":path", "/users/123"}};
   Buffer::OwnedImpl body;
   TransformationTemplate transformation;
@@ -357,8 +357,11 @@ TEST(Transformer, transformMultipleHeaderValues) {
 
   auto lowerkey = Http::LowerCaseString("x-custom-header");
   auto result = headers.get(lowerkey);
-  EXPECT_EQ("FIRST VALUE", result[0]->value().getStringView());
-  EXPECT_EQ("SECOND VALUE", result[1]->value().getStringView());
+  // Check original header value is preserved
+  EXPECT_EQ("original value", result[0]->value().getStringView());
+  // Check multiple transformed values are included
+  EXPECT_EQ("FIRST VALUE", result[1]->value().getStringView());
+  EXPECT_EQ("SECOND VALUE", result[2]->value().getStringView());
 }
 
 TEST(Transformer, transformSimpleNestedStructs) {

--- a/test/integration/transformation_filter_integration_test.cc
+++ b/test/integration/transformation_filter_integration_test.cc
@@ -31,6 +31,22 @@ const std::string DEFAULT_TRANSFORMATION =
         text: abc {{extraction("ext1")}}
 )EOF";
 
+const std::string DUPLICATE_HEADER_TRANSFORMATION = 
+    R"EOF(
+  request_transformation:
+    transformation_template:
+      headers_to_append:
+        - key: x-solo
+          value: 
+            text: appended header 1
+        - key: x-solo
+          value:
+            text: appended header 2
+        - key: x-new-header
+          value:
+            text: new header
+)EOF";
+
 const std::string BODY_TRANSFORMATION =
     R"EOF(
   request_transformation:
@@ -227,6 +243,31 @@ TEST_P(TransformationFilterIntegrationTest, TransformHeaderOnlyRequest) {
   EXPECT_EQ("solo.io", xsolo_header);
   std::string body = upstream_request_->body().toString();
   EXPECT_EQ("abc 234", body);
+}
+
+TEST_P(TransformationFilterIntegrationTest, KeepDuplicateHeaderRequest) {
+  transformation_string_ = DUPLICATE_HEADER_TRANSFORMATION;
+  initialize();
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":authority", "www.solo.io"},
+                                                 {":path", "/users/234"},
+                                                 {"x-solo", "original header"}};
+
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  processRequest(response);
+
+  const auto getHeader = [this](std::string header, int index) {
+    return upstream_request_->headers()
+                               .get(Http::LowerCaseString(header))[index]
+                               ->value()
+                               .getStringView();
+  };
+
+
+  EXPECT_EQ("original header", getHeader("x-solo", 0));
+  EXPECT_EQ("appended header 1", getHeader("x-solo", 1));
+  EXPECT_EQ("appended header 2", getHeader("x-solo", 2));
+  EXPECT_EQ("new header", getHeader("x-new-header", 0));
 }
 
 TEST_P(TransformationFilterIntegrationTest, TransformPathToOtherPath) {


### PR DESCRIPTION
Previously, the transformation filter removed multiple headers with the same header name from being processed. This adds a new field `headers_to_append`, which allows users to specify multiple template values for a header, and each of the headers values will be present in the final request.