### PR TITLE
bump alpine linux

### DIFF
--- a/changelog/v1.17.0-rc5/build-newer-alpineyaml.yaml
+++ b/changelog/v1.17.0-rc5/build-newer-alpineyaml.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Build a new version of the image so we pick up newer alpine linux, to resolve CVE


### PR DESCRIPTION
the dockerfile is not pinned, newer / latest version will be picked up by default