### PR TITLE
Update envoy 1.18

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -143,7 +143,7 @@ build:coverage --strategy=CoverageReport=sandboxed,local
 build:coverage --experimental_use_llvm_covmap
 build:coverage --collect_code_coverage
 build:coverage --test_tag_filters=-nocoverage
-build:coverage --instrumentation_filter="//source(?!/common/chromium_url|/extensions/quic_listeners/quiche/platform)[/:],//include[/:]"
+build:coverage --instrumentation_filter="//source(?!/common/chromium_url|/common/quic/platform)[/:],//include[/:]"
 coverage:test-coverage --test_arg="-l trace"
 coverage:fuzz-coverage --config=plain-fuzzer
 coverage:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh

--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -162,7 +162,6 @@ EXTENSIONS = {
     "envoy.transport_sockets.upstream_proxy_protocol": "//source/extensions/transport_sockets/proxy_protocol:upstream_config",
     "envoy.transport_sockets.raw_buffer": "//source/extensions/transport_sockets/raw_buffer:config",
     "envoy.transport_sockets.tap": "//source/extensions/transport_sockets/tap:config",
-    "envoy.transport_sockets.quic": "//source/extensions/quic_listeners/quiche:quic_factory_lib",
 
     #
     # Retry host predicates

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -2,7 +2,7 @@ REPOSITORY_LOCATIONS = dict(
     # bootstrap-callout branch of https://github.com/yuval-k/envoy
     # as of Dec 23rd 2020. Provides singleton fix for wasm plugin.
     envoy = dict(
-        commit = "2ee9543fbb0fccdb69d4dcd8cb57a19743afb94b",
+        commit = "345ffe37148b7a35b6e8e04db0300463689e3ff1",
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(

--- a/changelog/v1.18.0/bump-envoy.yaml
+++ b/changelog/v1.18.0/bump-envoy.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  description: Update envoy master with 1.18.0
+  dependencyOwner: envoyproxy
+  dependencyRepo: envoy
+  dependencyTag: 345ffe37148b7a35b6e8e04db0300463689e3ff1

--- a/test/integration/aws_lambda_filter_integration_test.cc
+++ b/test/integration/aws_lambda_filter_integration_test.cc
@@ -28,8 +28,7 @@ class AWSLambdaFilterIntegrationTest
       public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   AWSLambdaFilterIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(),
-                            realTime()) {}
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
 
   void TearDown() override {
     TestEnvironment::unsetEnvVar("AWS_ACCESS_KEY_ID");

--- a/test/integration/transformation_filter_integration_test.cc
+++ b/test/integration/transformation_filter_integration_test.cc
@@ -188,7 +188,7 @@ public:
       upstream_request_->encodeData(data, true);
     }
 
-    response->waitForEndStream();
+    ASSERT_TRUE(response->waitForEndStream());
   }
 
   std::string transformation_string_{DEFAULT_TRANSFORMATION};

--- a/test/integration/transformation_filter_integration_test.cc
+++ b/test/integration/transformation_filter_integration_test.cc
@@ -143,8 +143,7 @@ class TransformationFilterIntegrationTest
       public testing::TestWithParam<Network::Address::IpVersion> {
 public:
   TransformationFilterIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam(),
-                            realTime()) {}
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
 
   /**
    * Initializer for an individual integration test.


### PR DESCRIPTION
Bumps envoy to pick up CVE fixes:

CVE-2021-28682: Remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior. 
CVE-2021-28683: Crash when peer sends a TLS Alert with an unknown code
CVE-2021-29258: Remotely exploitable crash in Envoy's HTTP2 Metadata, when an empty METADATA map is sent.
