### PR TITLE
Update envoy 1.17

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,9 +1,11 @@
 REPOSITORY_LOCATIONS = dict(
     # bootstrap-callout branch of https://github.com/yuval-k/envoy
     # as of Dec 23rd 2020. Provides singleton fix for wasm plugin.
+
+    # v1.17.2 release
     envoy = dict(
-        commit = "449118844b8b8eb5533ea50117d3789033bf2f9f",
-        remote = "https://github.com/yuval-k/envoy",
+        commit = "21fe4496ca0c7798d6a9a747fdbf1ec1071e7f4f",
+        remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(
         commit = "4c0ee3a46c0bbb279b0849e5a659e52684a37a98",

--- a/changelog/v1.17.2/bump-envoy.yaml
+++ b/changelog/v1.17.2/bump-envoy.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  description: Update envoy master with 1.17.2
+  dependencyOwner: envoyproxy
+  dependencyRepo: envoy
+  dependencyTag: 21fe4496ca0c7798d6a9a747fdbf1ec1071e7f4f


### PR DESCRIPTION
Bumps envoy to pick up CVE fixes:

CVE-2021-28682: Remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.
CVE-2021-28683: Crash when peer sends a TLS Alert with an unknown code
CVE-2021-29258: Remotely exploitable crash in Envoy's HTTP2 Metadata, when an empty METADATA map is sent.