### PR TITLE
Update envoy 1.16

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
-    # envoy master-v1.16.0
+    # envoy v1.16.2
     envoy = dict(
-        commit = "0717f49fef0dac3818cd7cdc52bf18e0ae1f7a2c",
+        commit = "c4b7ab805f238206d8b806e12cedb9420e5d936a",
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(

--- a/changelog/v1.16.3/bump-envoy.yaml
+++ b/changelog/v1.16.3/bump-envoy.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  description: Update envoy master with 1.17.2
+  dependencyOwner: envoyproxy
+  dependencyRepo: envoy
+  dependencyTag: c4b7ab805f238206d8b806e12cedb9420e5d936a


### PR DESCRIPTION
Bumps envoy to pick up CVE fixes:

CVE-2021-28682: Remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.
CVE-2021-28683: Crash when peer sends a TLS Alert with an unknown code
CVE-2021-29258: Remotely exploitable crash in Envoy's HTTP2 Metadata, when an empty METADATA map is sent.