### PR TITLE
Access log transformer

### DIFF
--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -46,9 +46,8 @@ message TransformationRule {
     bool clear_route_cache = 3;
     // Apply a transformation to responses.
     Transformation response_transformation = 2;
-    // Apply a transformation in the onStreamComplete callback 
-    // (for modifying access logs)
-    Transformation access_log_transformation = 4;
+    // Apply a transformation in the onStreamComplete callback
+    Transformation on_stream_completion_transformation = 4;
   }
   // transformation to perform
   Transformations route_transformations = 2;

--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -46,6 +46,9 @@ message TransformationRule {
     bool clear_route_cache = 3;
     // Apply a transformation to responses.
     Transformation response_transformation = 2;
+    // Apply a transformation in the onStreamComplete callback 
+    // (for modifying access logs)
+    Transformation access_log_transformation = 4;
   }
   // transformation to perform
   Transformations route_transformations = 2;

--- a/changelog/v1.19.0-rc2/add-access-log-transformer-interface.yaml
+++ b/changelog/v1.19.0-rc2/add-access-log-transformer-interface.yaml
@@ -1,7 +1,0 @@
-changelog:
-- type: NEW_FEATURE
-  issueLink: https://github.com/solo-io/gloo/issues/4282
-  resolvesIssue: false
-  description: >
-    Add `access_log_transformation` route transformation interface to allow transforming header
-    maps in the onStreamComplete callback.

--- a/changelog/v1.19.0-rc2/add-access-log-transformer-interface.yaml
+++ b/changelog/v1.19.0-rc2/add-access-log-transformer-interface.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo/issues/4282
+  resolvesIssue: false
+  description: >
+    Add `access_log_transformation` route transformation interface to allow transforming header
+    maps in the onStreamComplete callback.

--- a/changelog/v1.19.0-rc2/add-stream-complete-transformer-interface.yaml
+++ b/changelog/v1.19.0-rc2/add-stream-complete-transformer-interface.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo/issues/4282
+  resolvesIssue: false
+  description: >
+    Add `on_stream_complete_transformation` route transformation interface to allow
+    transforming header maps in the onStreamComplete callback.

--- a/source/extensions/filters/http/transformation/BUILD
+++ b/source/extensions/filters/http/transformation/BUILD
@@ -47,6 +47,7 @@ envoy_cc_library(
         "//source/extensions/filters/http:solo_well_known_names",
         "@envoy//source/common/common:enum_to_int",
         "@envoy//source/common/config:metadata_lib",
+        "@envoy//source/common/http:header_map_lib",
         "@envoy//source/common/http:utility_lib",
         "@envoy//include/envoy/stats:stats_interface",
         "@envoy//include/envoy/stats:stats_macros",

--- a/source/extensions/filters/http/transformation/body_header_transformer.cc
+++ b/source/extensions/filters/http/transformation/body_header_transformer.cc
@@ -14,7 +14,7 @@ namespace Transformation {
 
 void BodyHeaderTransformer::transform(
     Http::RequestOrResponseHeaderMap &header_map,
-    const Http::RequestHeaderMap *, Buffer::Instance &body,
+    Http::RequestHeaderMap *, Buffer::Instance &body,
     Http::StreamFilterCallbacks &) const {
   json json_body;
   if (body.length() > 0) {

--- a/source/extensions/filters/http/transformation/body_header_transformer.h
+++ b/source/extensions/filters/http/transformation/body_header_transformer.h
@@ -12,7 +12,7 @@ namespace Transformation {
 class BodyHeaderTransformer : public Transformer {
 public:
   void transform(Http::RequestOrResponseHeaderMap &map,
-                 const Http::RequestHeaderMap *request_headers,
+                 Http::RequestHeaderMap *request_headers,
                  Buffer::Instance &body,
                  Http::StreamFilterCallbacks &) const override;
   bool passthrough_body() const override { return false; };

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -351,7 +351,7 @@ InjaTransformer::InjaTransformer(const TransformationTemplate &transformation)
 InjaTransformer::~InjaTransformer() {}
 
 void InjaTransformer::transform(Http::RequestOrResponseHeaderMap &header_map,
-                                const Http::RequestHeaderMap *request_headers,
+                                Http::RequestHeaderMap *request_headers,
                                 Buffer::Instance &body,
                                 Http::StreamFilterCallbacks &callbacks) const {
   absl::optional<std::string> string_body;

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -77,7 +77,7 @@ public:
   ~InjaTransformer();
 
   void transform(Http::RequestOrResponseHeaderMap &map,
-                 const Http::RequestHeaderMap *request_headers,
+                 Http::RequestHeaderMap *request_headers,
                  Buffer::Instance &body,
                  Http::StreamFilterCallbacks &) const override;
   bool passthrough_body() const override { return passthrough_body_; };

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -218,11 +218,13 @@ void TransformationFilter::transformOnStreamCompletion() {
   // Body isn't required for this transformer since it isn't included
   // in access logs
   Buffer::OwnedImpl emptyBody{};
+  std::unique_ptr<Http::ResponseHeaderMapImpl> emptyResponseHeaderMap = 
+      Http::ResponseHeaderMapImpl::create();
 
   // If response_headers_ is a nullptr (this can happpen if a client disconnects)
   // we pass in an empty response header to avoid errors within the transformer.
   if (response_headers_ == nullptr) {
-    response_headers_ = Http::ResponseHeaderMapImpl::create().get();
+    response_headers_ = emptyResponseHeaderMap.get();
   }
 
   try {

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -220,7 +220,7 @@ void TransformationFilter::transformOnStreamCompletion() {
   Buffer::OwnedImpl emptyBody{};
   try {
     on_stream_completion_transformation_->transform(*response_headers_,
-                                                    *request_headers_, 
+                                                    request_headers_, 
                                                     emptyBody, 
                                                     *on_complete_callbacks);
   } catch (std::exception &e)  {
@@ -239,7 +239,7 @@ void TransformationFilter::transformSomething(
     void (TransformationFilter::*addData)(Buffer::Instance &)) {
 
   try {
-    transformation->transform(header_map, *request_headers_, body, callbacks);
+    transformation->transform(header_map, request_headers_, body, callbacks);
 
     if (body.length() > 0) {
       (this->*addData)(body);

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -215,10 +215,14 @@ void TransformationFilter::transformOnStreamCompletion() {
   }
 
   Http::StreamFilterCallbacks *on_complete_callbacks{};
+  // Body isn't required for this transformer since it isn't included
+  // in access logs
+  Buffer::OwnedImpl emptyBody{};
   try {
-    on_stream_completion_transformation_->transform_headers(*request_headers_,
-                                                            *response_headers_,
-                                                            *on_complete_callbacks);
+    on_stream_completion_transformation_->transform(*response_headers_,
+                                                    *request_headers_, 
+                                                    emptyBody, 
+                                                    *on_complete_callbacks);
   } catch (std::exception &e)  {
     ENVOY_STREAM_LOG(debug, 
                      "failure transforming on stream completion {}", 
@@ -235,7 +239,7 @@ void TransformationFilter::transformSomething(
     void (TransformationFilter::*addData)(Buffer::Instance &)) {
 
   try {
-    transformation->transform(header_map, request_headers_, body, callbacks);
+    transformation->transform(header_map, *request_headers_, body, callbacks);
 
     if (body.length() > 0) {
       (this->*addData)(body);

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -228,6 +228,7 @@ void TransformationFilter::transformOnStreamCompletion() {
                      "failure transforming on stream completion {}", 
                      *on_complete_callbacks, 
                      e.what());
+    filter_config_->stats().on_stream_complete_error_.inc();
   }
 }
 

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -215,7 +215,6 @@ void TransformationFilter::transformOnStreamCompletion() {
     return;
   }
 
-  Http::StreamFilterCallbacks *on_complete_callbacks{};
   // Body isn't required for this transformer since it isn't included
   // in access logs
   Buffer::OwnedImpl emptyBody{};
@@ -230,11 +229,11 @@ void TransformationFilter::transformOnStreamCompletion() {
     on_stream_completion_transformation_->transform(*response_headers_,
                                                     request_headers_, 
                                                     emptyBody, 
-                                                    *on_complete_callbacks);
+                                                    *encoder_callbacks_);
   } catch (std::exception &e)  {
     ENVOY_STREAM_LOG(debug, 
                      "failure transforming on stream completion {}", 
-                     *on_complete_callbacks, 
+                     *encoder_callbacks_, 
                      e.what());
     filter_config_->stats().on_stream_complete_error_.inc();
   }

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -4,6 +4,7 @@
 #include "common/common/enum_to_int.h"
 #include "common/config/metadata.h"
 #include "common/http/header_utility.h"
+#include "common/http/header_map_impl.h"
 #include "common/http/utility.h"
 
 #include "extensions/filters/http/solo_well_known_names.h"
@@ -218,6 +219,13 @@ void TransformationFilter::transformOnStreamCompletion() {
   // Body isn't required for this transformer since it isn't included
   // in access logs
   Buffer::OwnedImpl emptyBody{};
+
+  // If response_headers_ is a nullptr (this can happpen if a client disconnects)
+  // we pass in an empty response header to avoid errors within the transformer.
+  if (response_headers_ == nullptr) {
+    response_headers_ = Http::ResponseHeaderMapImpl::create().get();
+  }
+
   try {
     on_stream_completion_transformation_->transform(*response_headers_,
                                                     request_headers_, 

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -215,18 +215,10 @@ void TransformationFilter::transformOnStreamCompletion() {
   }
 
   Http::StreamFilterCallbacks *on_complete_callbacks{};
-  // Body isn't required for this transformer since it isn't included
-  // in access logs
-  Buffer::OwnedImpl emptyBody{};
   try {
-    on_stream_completion_transformation_->transform(*response_headers_,
-                                                    request_headers_, 
-                                                    emptyBody, 
-                                                    *on_complete_callbacks);
-    on_stream_completion_transformation_->transform(*request_headers_,
-                                                    request_headers_, 
-                                                    emptyBody, 
-                                                    *on_complete_callbacks);
+    on_stream_completion_transformation_->transform_headers(*request_headers_,
+                                                            *response_headers_,
+                                                            *on_complete_callbacks);
   } catch (std::exception &e)  {
     ENVOY_STREAM_LOG(debug, 
                      "failure transforming on stream completion {}", 

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -218,12 +218,12 @@ void TransformationFilter::transformOnStreamCompletion() {
   // Body isn't required for this transformer since it isn't included
   // in access logs
   Buffer::OwnedImpl emptyBody{};
-  std::unique_ptr<Http::ResponseHeaderMapImpl> emptyResponseHeaderMap = 
-      Http::ResponseHeaderMapImpl::create();
+  std::unique_ptr<Http::ResponseHeaderMapImpl> emptyResponseHeaderMap;
 
   // If response_headers_ is a nullptr (this can happpen if a client disconnects)
   // we pass in an empty response header to avoid errors within the transformer.
   if (response_headers_ == nullptr) {
+    emptyResponseHeaderMap = Http::ResponseHeaderMapImpl::create();
     response_headers_ = emptyResponseHeaderMap.get();
   }
 

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -223,6 +223,10 @@ void TransformationFilter::transformOnStreamCompletion() {
                                                     request_headers_, 
                                                     emptyBody, 
                                                     *on_complete_callbacks);
+    on_stream_completion_transformation_->transform(*request_headers_,
+                                                    request_headers_, 
+                                                    emptyBody, 
+                                                    *on_complete_callbacks);
   } catch (std::exception &e)  {
     ENVOY_STREAM_LOG(debug, 
                      "failure transforming on stream completion {}", 

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -210,13 +210,20 @@ void TransformationFilter::addEncoderData(Buffer::Instance &data) {
 }
 
 void TransformationFilter::transformAccessLogs() {
+  if (access_log_transformation_ == nullptr) {
+    return;
+  }
+
   Http::StreamFilterCallbacks *on_complete_callbacks{};
+  // Body isn't required for this transformer since it isn't included
+  // in access logs
   Buffer::OwnedImpl emptyBody{};
   try {
     access_log_transformation_->transform(*response_headers_,
                                           request_headers_, 
                                           emptyBody, 
                                           *on_complete_callbacks);
+    
   } catch (std::exception &e)  {
     ENVOY_STREAM_LOG(debug, 
                      "failure transforming access logs {}", 

--- a/source/extensions/filters/http/transformation/transformation_filter.h
+++ b/source/extensions/filters/http/transformation/transformation_filter.h
@@ -27,6 +27,8 @@ public:
   // Http::FunctionalFilterBase
   void onDestroy() override;
 
+  void onStreamComplete() override;
+
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap &,
                                           bool) override;
@@ -85,6 +87,7 @@ private:
 
   void transformRequest();
   void transformResponse();
+  void transformAccessLogs();
 
   void addDecoderData(Buffer::Instance &data);
   void addEncoderData(Buffer::Instance &data);
@@ -111,6 +114,7 @@ private:
 
   TransformerConstSharedPtr request_transformation_;
   TransformerConstSharedPtr response_transformation_;
+  TransformerConstSharedPtr access_log_transformation_;
   absl::optional<Error> error_;
   Http::Code error_code_;
   std::string error_messgae_;

--- a/source/extensions/filters/http/transformation/transformation_filter.h
+++ b/source/extensions/filters/http/transformation/transformation_filter.h
@@ -87,7 +87,7 @@ private:
 
   void transformRequest();
   void transformResponse();
-  void transformAccessLogs();
+  void transformOnStreamCompletion();
 
   void addDecoderData(Buffer::Instance &data);
   void addEncoderData(Buffer::Instance &data);
@@ -114,7 +114,7 @@ private:
 
   TransformerConstSharedPtr request_transformation_;
   TransformerConstSharedPtr response_transformation_;
-  TransformerConstSharedPtr access_log_transformation_;
+  TransformerConstSharedPtr on_stream_completion_transformation_;
   absl::optional<Error> error_;
   Http::Code error_code_;
   std::string error_messgae_;

--- a/source/extensions/filters/http/transformation/transformation_filter_config.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.cc
@@ -48,7 +48,7 @@ TransformationFilterConfig::TransformationFilterConfig(
     }
     TransformerConstSharedPtr request_transformation;
     TransformerConstSharedPtr response_transformation;
-    TransformerConstSharedPtr access_log_transformation;
+    TransformerConstSharedPtr on_stream_completion_transformation;
     bool clear_route_cache = false;
     if (rule.has_route_transformations()) {
       const auto &route_transformation = rule.route_transformations();
@@ -71,20 +71,20 @@ TransformationFilterConfig::TransformationFilterConfig(
               fmt::format("Failed to parse response template: {}", e.what()));
         }
       }
-      if (route_transformation.has_access_log_transformation()) {
+      if (route_transformation.has_on_stream_completion_transformation()) {
         try {
-          access_log_transformation = Transformation::getTransformer(
-              route_transformation.access_log_transformation(), context);
+          on_stream_completion_transformation = Transformation::getTransformer(
+              route_transformation.on_stream_completion_transformation(), context);
         } catch (const std::exception &e) {
           throw EnvoyException(
-              fmt::format("Failed to parse access log template: {}", e.what()));
+              fmt::format("Failed to parse on stream completion template: {}", e.what()));
         }
       }
     }
     TransformerPairConstSharedPtr transformer_pair =
         std::make_unique<TransformerPair>(request_transformation,
                                           response_transformation,
-                                          access_log_transformation,
+                                          on_stream_completion_transformation,
                                           clear_route_cache);
     transformer_pairs_.emplace_back(Matcher::Matcher::create(rule.match()),
                                     transformer_pair);

--- a/source/extensions/filters/http/transformation/transformation_filter_config.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.cc
@@ -77,7 +77,7 @@ TransformationFilterConfig::TransformationFilterConfig(
               route_transformation.on_stream_completion_transformation(), context);
         } catch (const std::exception &e) {
           throw EnvoyException(
-              fmt::format("Failed to parse on stream completion template: {}", e.what()));
+              fmt::format("Failed to get the on stream completion transformation: {}", e.what()));
         }
       }
     }

--- a/source/extensions/filters/http/transformation/transformer.cc
+++ b/source/extensions/filters/http/transformation/transformer.cc
@@ -11,10 +11,12 @@ constexpr uint64_t MAX_STAGE_NUMBER = 10UL;
 
 TransformerPair::TransformerPair(TransformerConstSharedPtr request_transformer,
                                  TransformerConstSharedPtr response_transformer,
+                                 TransformerConstSharedPtr access_log_transformer,
                                  bool should_clear_cache)
     : clear_route_cache_(should_clear_cache),
       request_transformation_(request_transformer),
-      response_transformation_(response_transformer) {}
+      response_transformation_(response_transformer),
+      access_log_transformation_(access_log_transformer) {}
 
 TransformerPairConstSharedPtr
 FilterConfig::findTransformers(const Http::RequestHeaderMap &headers) const {

--- a/source/extensions/filters/http/transformation/transformer.cc
+++ b/source/extensions/filters/http/transformation/transformer.cc
@@ -11,12 +11,12 @@ constexpr uint64_t MAX_STAGE_NUMBER = 10UL;
 
 TransformerPair::TransformerPair(TransformerConstSharedPtr request_transformer,
                                  TransformerConstSharedPtr response_transformer,
-                                 TransformerConstSharedPtr access_log_transformer,
+                                 TransformerConstSharedPtr on_stream_completion_transformer,
                                  bool should_clear_cache)
     : clear_route_cache_(should_clear_cache),
       request_transformation_(request_transformer),
       response_transformation_(response_transformer),
-      access_log_transformation_(access_log_transformer) {}
+      on_stream_completion_transformation_(on_stream_completion_transformer) {}
 
 TransformerPairConstSharedPtr
 FilterConfig::findTransformers(const Http::RequestHeaderMap &headers) const {

--- a/source/extensions/filters/http/transformation/transformer.h
+++ b/source/extensions/filters/http/transformation/transformer.h
@@ -27,7 +27,8 @@ namespace Transformation {
   COUNTER(response_header_transformations)                                     \
   COUNTER(response_body_transformations)                                       \
   COUNTER(request_error)                                                       \
-  COUNTER(response_error)
+  COUNTER(response_error)                                                      \
+  COUNTER(on_stream_complete_error)
 
 /**
  * Wrapper struct for transformation @see stats_macros.h

--- a/source/extensions/filters/http/transformation/transformer.h
+++ b/source/extensions/filters/http/transformation/transformer.h
@@ -45,12 +45,9 @@ public:
   virtual void transform(Http::RequestOrResponseHeaderMap &map,
                          // request header map. this has the request header map
                          // even when transforming responses.
-                         const Http::RequestHeaderMap *request_headers,
+                         Http::RequestHeaderMap *request_headers,
                          Buffer::Instance &body,
                          Http::StreamFilterCallbacks &callbacks) const PURE;
-  virtual void transform_headers(Http::RequestHeaderMap &,
-                                 Http::ResponseHeaderMap &,
-                                 Http::StreamFilterCallbacks &) const {};
 };
 
 typedef std::shared_ptr<const Transformer> TransformerConstSharedPtr;

--- a/source/extensions/filters/http/transformation/transformer.h
+++ b/source/extensions/filters/http/transformation/transformer.h
@@ -56,6 +56,7 @@ class TransformerPair {
 public:
   TransformerPair(TransformerConstSharedPtr request_transformer,
                   TransformerConstSharedPtr response_transformer,
+                  TransformerConstSharedPtr access_log_transformer,
                   bool should_clear_cache);
 
   TransformerConstSharedPtr getRequestTranformation() const {
@@ -66,12 +67,17 @@ public:
     return response_transformation_;
   }
 
+  TransformerConstSharedPtr getAccessLogTransformation() const {
+    return access_log_transformation_;
+  }
+
   bool shouldClearCache() const { return clear_route_cache_; }
 
 private:
   bool clear_route_cache_{};
   TransformerConstSharedPtr request_transformation_;
   TransformerConstSharedPtr response_transformation_;
+  TransformerConstSharedPtr access_log_transformation_;
 };
 typedef std::shared_ptr<const TransformerPair> TransformerPairConstSharedPtr;
 

--- a/source/extensions/filters/http/transformation/transformer.h
+++ b/source/extensions/filters/http/transformation/transformer.h
@@ -56,7 +56,7 @@ class TransformerPair {
 public:
   TransformerPair(TransformerConstSharedPtr request_transformer,
                   TransformerConstSharedPtr response_transformer,
-                  TransformerConstSharedPtr access_log_transformer,
+                  TransformerConstSharedPtr on_stream_completion_transformer,
                   bool should_clear_cache);
 
   TransformerConstSharedPtr getRequestTranformation() const {
@@ -67,8 +67,8 @@ public:
     return response_transformation_;
   }
 
-  TransformerConstSharedPtr getAccessLogTransformation() const {
-    return access_log_transformation_;
+  TransformerConstSharedPtr getOnStreamCompletionTransformation() const {
+    return on_stream_completion_transformation_;
   }
 
   bool shouldClearCache() const { return clear_route_cache_; }
@@ -77,7 +77,7 @@ private:
   bool clear_route_cache_{};
   TransformerConstSharedPtr request_transformation_;
   TransformerConstSharedPtr response_transformation_;
-  TransformerConstSharedPtr access_log_transformation_;
+  TransformerConstSharedPtr on_stream_completion_transformation_;
 };
 typedef std::shared_ptr<const TransformerPair> TransformerPairConstSharedPtr;
 

--- a/source/extensions/filters/http/transformation/transformer.h
+++ b/source/extensions/filters/http/transformation/transformer.h
@@ -48,6 +48,9 @@ public:
                          const Http::RequestHeaderMap *request_headers,
                          Buffer::Instance &body,
                          Http::StreamFilterCallbacks &callbacks) const PURE;
+  virtual void transform_headers(Http::RequestHeaderMap &,
+                                 Http::ResponseHeaderMap &,
+                                 Http::StreamFilterCallbacks &) const {};
 };
 
 typedef std::shared_ptr<const Transformer> TransformerConstSharedPtr;

--- a/test/extensions/filters/http/transformation/fake_transformer.h
+++ b/test/extensions/filters/http/transformation/fake_transformer.h
@@ -15,7 +15,7 @@ public:
   void transform (Http::RequestOrResponseHeaderMap &,
                          // request header map. this has the request header map
                          // even when transforming responses.
-                         const Http::RequestHeaderMap *,
+                         Http::RequestHeaderMap *,
                          Buffer::Instance &,
                          Http::StreamFilterCallbacks &) const override {
   }

--- a/test/extensions/filters/http/transformation/transformation_filter_test.cc
+++ b/test/extensions/filters/http/transformation/transformation_filter_test.cc
@@ -721,9 +721,10 @@ TEST_F(TransformationFilterTest, WithoutResponseHeaderOnStreamComplete) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, res);
   EXPECT_EQ(EMPTY_STRING, headers_.get_("added-header"));
 
-  // onStreamComplete shouuld be successful despite
+  // onStreamComplete should be successful (no errors) despite
   // response_headers being a nullptr (since it wasn't encoded)
   EXPECT_NO_THROW(filter_->onStreamComplete());
+  EXPECT_EQ(0U, config_->stats().on_stream_complete_error_.value());
 }
 
 TEST_F(TransformationFilterTest, ErroredOnStreamComplete) {
@@ -741,8 +742,8 @@ TEST_F(TransformationFilterTest, ErroredOnStreamComplete) {
   res = filter_->encodeHeaders(response_headers, true);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, res);
   
-  // Raise an arbitrary error during a call that is done in
-  // the Inja transformer
+  // Raise an arbitrary error during a call that is triggeres
+  // during the Inja header transformer
   ON_CALL(encoder_filter_callbacks_, clusterInfo())
         .WillByDefault(Throw(std::runtime_error("arbitrary error")));
 

--- a/test/extensions/filters/http/transformation/transformation_filter_test.cc
+++ b/test/extensions/filters/http/transformation/transformation_filter_test.cc
@@ -16,6 +16,7 @@ using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;
 using testing::SaveArg;
+using testing::Throw;
 using testing::WithArg;
 
 namespace Envoy {
@@ -200,6 +201,21 @@ public:
       auto &transformation = (*route_config_.mutable_request_transformation());
       transformation.mutable_header_body_transform();
     }
+    initFilter(); // Re-load config.
+  }
+
+  void initOnStreamCompleteTransformHeader() {
+    auto &route_matcher = (*transformation_rule_.mutable_match());
+    route_matcher.set_prefix("/");
+    null_route_config_ = true;
+    auto &transformation =
+        (*transformation_rule_.mutable_route_transformations()
+            ->mutable_on_stream_completion_transformation());
+    transformation.mutable_transformation_template()->mutable_passthrough();
+    envoy::api::v2::filter::http::InjaTemplate header_value;
+    header_value.set_text("added-value");
+    (*transformation.mutable_transformation_template()
+          ->mutable_headers())["added-header"] = header_value;
     initFilter(); // Re-load config.
   }
 
@@ -670,6 +686,70 @@ TEST_F(TransformationFilterTest, HappyPathWithHeadersBodyTemplate) {
   Buffer::OwnedImpl downstream_body("testbody");
   auto res = filter_->decodeData(downstream_body, true);
   EXPECT_EQ(Http::FilterDataStatus::Continue, res);
+}
+
+TEST_F(TransformationFilterTest, HappyPathOnStreamComplete) {
+  initOnStreamCompleteTransformHeader();
+
+  Http::TestResponseHeaderMapImpl response_headers{
+    {"content-type", "test"},
+    {":method", "GET"},
+    {":authority", "www.solo.io"},
+    {":path", "/path"}};
+
+  // Create response and request headers
+  auto res = filter_->decodeHeaders(headers_, true);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, res);
+  res = filter_->encodeHeaders(response_headers, true);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, res);
+  
+  // Header should not be added yet
+  EXPECT_EQ(EMPTY_STRING, headers_.get_("added-header"));
+  EXPECT_EQ(EMPTY_STRING, response_headers.get_("added-header"));
+
+  filter_->onStreamComplete();
+  // Header is added to response headers as part of onStreamComplete
+  EXPECT_EQ("added-value", response_headers.get_("added-header"));
+  EXPECT_EQ(EMPTY_STRING, headers_.get_("added-header"));
+}
+
+TEST_F(TransformationFilterTest, WithoutResponseHeaderOnStreamComplete) {
+  initOnStreamCompleteTransformHeader();
+
+  // There are only request headers
+  auto res = filter_->decodeHeaders(headers_, true);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, res);
+  EXPECT_EQ(EMPTY_STRING, headers_.get_("added-header"));
+
+  // onStreamComplete shouuld be successful despite
+  // response_headers being a nullptr (since it wasn't encoded)
+  EXPECT_NO_THROW(filter_->onStreamComplete());
+}
+
+TEST_F(TransformationFilterTest, ErroredOnStreamComplete) {
+  initOnStreamCompleteTransformHeader();
+
+  Http::TestResponseHeaderMapImpl response_headers{
+    {"content-type", "test"},
+    {":method", "GET"},
+    {":authority", "www.solo.io"},
+    {":path", "/path"}};
+
+  // Create response and request headers
+  auto res = filter_->decodeHeaders(headers_, true);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, res);
+  res = filter_->encodeHeaders(response_headers, true);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, res);
+  
+  // Raise an arbitrary error during a call that is done in
+  // the Inja transformer
+  ON_CALL(encoder_filter_callbacks_, clusterInfo())
+        .WillByDefault(Throw(std::runtime_error("arbitrary error")));
+
+  // Verify that error is caught and stat is incremented
+  EXPECT_NO_THROW(filter_->onStreamComplete());
+  EXPECT_EQ(1U, config_->stats().on_stream_complete_error_.value());
+ 
 }
 
 } // namespace Transformation


### PR DESCRIPTION
This PR adds the `onStreamComplete` callback to the transformation filter. This will allow us to further implement transforming headers that will be logged (to be done in Envoy Gloo EE [here](https://github.com/solo-io/envoy-gloo-ee/pull/148))