### PR TITLE
Fix extractor regex

### DIFF
--- a/changelog/v1.19.0-rc5/fix-extractor-regex-search.yaml
+++ b/changelog/v1.19.0-rc5/fix-extractor-regex-search.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5000
+    resolvesIssue: false
+    description: >
+      Fixes issue where extractor regex's need to match the *entire* text in order
+      any match to be found. This is not ideal for situations where you only want the regex
+      to match on a subsection of the input text. Changing the underlying method from `regex_match` to
+      `regex_search` fixes this behaviour. 

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -86,7 +86,7 @@ Extractor::extractValue(Http::StreamFilterCallbacks &callbacks,
                         absl::string_view value) const {
   // get and regex
   std::match_results<absl::string_view::const_iterator> regex_result;
-  if (std::regex_match(value.begin(), value.end(), regex_result,
+  if (std::regex_search(value.begin(), value.end(), regex_result,
                        extract_regex_)) {
     if (group_ >= regex_result.size()) {
       // this should never happen as we test this in the ctor.

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -227,6 +227,23 @@ TEST(Extraction, ExtractIdFromHeader) {
   EXPECT_EQ("123", res);
 }
 
+TEST(Extraction, ExtractIdFromBody) {
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":authority", "www.solo.io"}};
+  envoy::api::v2::filter::http::Extraction extractor;
+  extractor.mutable_body();
+  extractor.set_regex("id: ([0-9]{4})");
+  extractor.set_subgroup(1);
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  std::string body(R"EOF(
+    id: 1234
+  )EOF");
+  GetBodyFunc bodyfunc = [&body]() -> const std::string & { return body; };
+  std::string res(Extractor(extractor).extract(callbacks, headers, bodyfunc));
+
+  EXPECT_EQ("1234", res);
+}
+
 TEST(Extraction, ExtractorWorkWithNewlines) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                          {":authority", "www.solo.io"},


### PR DESCRIPTION
If we define a request body as 
```
"here is some body with new lines
id: 1234
"
```
and regex in extractor 
```yaml
myExtractor:
  regex: 'id: ([0-9]{4})'
  subgroup: 1
```
we'd expect the extracted string to be `1234`. However our extractor regex logic doesn't currently work like this. The regex needs to match the **entire** body / input text in order for a match to be found. This is because we use the `std:regex_match` method. I believe `std:regex_search` is closer to the expected behavior of extractor regex.
