### PR TITLE
Upgrade Envoy 1.19.0-patch2

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,8 +1,8 @@
 REPOSITORY_LOCATIONS = dict(
-    # envoy 1.19.0
+    # envoy 1.19.0-patch2
     envoy = dict(
-        commit = "68fe53a889416fd8570506232052b06f5a531541",
-        remote = "https://github.com/envoyproxy/envoy",
+        commit = "a837c56012d86284b8c6a1b7da87ee7c18c23d43",
+        remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(
         commit = "4c0ee3a46c0bbb279b0849e5a659e52684a37a98",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,5 +1,5 @@
 REPOSITORY_LOCATIONS = dict(
-    # envoy 1.19.0-patch2
+    # we depend on envoy 1.19.0 with the cve patches applied on top (https://github.com/solo-io/envoy-fork/commits/release/v1.19.0-patch), since 1.19.1 would pick up changes that break our transformation filter and its unit tests
     envoy = dict(
         commit = "a837c56012d86284b8c6a1b7da87ee7c18c23d43",
         remote = "https://github.com/solo-io/envoy-fork",

--- a/changelog/v1.19.0-patch2/bump-envoy.yaml
+++ b/changelog/v1.19.0-patch2/bump-envoy.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    description: Update envoy to 1.19.0-patch2 for CVE-2021-32777, CVE-2021-32779, CVE-2021-32781, CVE-2021-32778, CVE-2021-32780
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-fork
+    dependencyTag: a837c56012d86284b8c6a1b7da87ee7c18c23d43


### PR DESCRIPTION
Update envoy to 1.19.0-patch2 for CVE-2021-32777, CVE-2021-32779, CVE-2021-32781, CVE-2021-32778, CVE-2021-32780

