### PR TITLE
Respect lambda fxn errors and treat as 504

### DIFF
--- a/changelog/v1.19.0-patch4/bump-envoy.yaml
+++ b/changelog/v1.19.0-patch4/bump-envoy.yaml
@@ -1,5 +1,5 @@
 changelog:
-- type: NEW_FEATURE
+- type: FIX
   issueLink: https://github.com/solo-io/gloo/issues/5618
   resolvesIssue: true
   description: >

--- a/changelog/v1.19.0-patch4/bump-envoy.yaml
+++ b/changelog/v1.19.0-patch4/bump-envoy.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo/issues/5618
+  resolvesIssue: true
+  description: >
+    Updates lambda to correctly handle upstream errors that are not encoded in status but rather in the error header.

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -126,7 +126,7 @@ Http::FilterHeadersStatus
 AWSLambdaFilter::encodeHeaders(Http::ResponseHeaderMap &headers, bool ) {
 
   if (!headers.get(AWSLambdaHeaderNames::get().FunctionError).empty()){
-    // We treat upstream errors as if it was any other upstream error
+    // We treat upstream function errors as if it was any other upstream error
     headers.setStatus(504);
     return Http::FilterHeadersStatus::Continue;
   }

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -164,7 +164,6 @@ void AWSLambdaFilter::onSuccess(
                                        RcDetails::get().CredentialsNotFound);
     return;
   }
- 
   aws_authenticator_.init(access_key, secret_key, session_token);
 
   request_headers_->setReferenceMethod(Http::Headers::get().MethodValues.Post);
@@ -236,7 +235,6 @@ AWSLambdaFilter::decodeTrailers(Http::RequestTrailerMap &) {
 }
 
 void AWSLambdaFilter::lambdafy() {
-  
   handleDefaultBody();
 
   const std::string &invocation_type =

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -128,7 +128,6 @@ AWSLambdaFilter::encodeHeaders(Http::ResponseHeaderMap &headers, bool ) {
   if (!headers.get(AWSLambdaHeaderNames::get().FunctionError).empty()){
     // We treat upstream function errors as if it was any other upstream error
     headers.setStatus(504);
-    return Http::FilterHeadersStatus::Continue;
   }
   return Http::FilterHeadersStatus::Continue;
 }

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -133,16 +133,6 @@ AWSLambdaFilter::encodeHeaders(Http::ResponseHeaderMap &headers, bool ) {
   return Http::FilterHeadersStatus::StopIteration;
 }
 
-Http::FilterDataStatus AWSLambdaFilter::encodeData(Buffer::Instance &,
-                                                        bool ) {
-  return Http::FilterDataStatus::Continue;
-}
-
-Http::FilterTrailersStatus
-AWSLambdaFilter::encodeTrailers(Http::ResponseTrailerMap &) {
-  return Http::FilterTrailersStatus::StopIteration;
-}
-
 void AWSLambdaFilter::onSuccess(
     std::shared_ptr<const Envoy::Extensions::Common::Aws::Credentials>
         credentials) {

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -130,7 +130,7 @@ AWSLambdaFilter::encodeHeaders(Http::ResponseHeaderMap &headers, bool ) {
     headers.setStatus(504);
     return Http::FilterHeadersStatus::Continue;
   }
-  return Http::FilterHeadersStatus::StopIteration;
+  return Http::FilterHeadersStatus::Continue;
 }
 
 void AWSLambdaFilter::onSuccess(

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -43,6 +43,7 @@ public:
   const Http::LowerCaseString LogType{"x-amz-log-type"};
   const std::string LogNone{"None"};
   const Http::LowerCaseString HostHead{"x-amz-log-type"};
+  const Http::LowerCaseString FunctionError{"x-amz-function-error"};
 };
 
 typedef ConstSingleton<AWSLambdaHeaderValues> AWSLambdaHeaderNames;
@@ -120,6 +121,28 @@ AWSLambdaFilter::decodeHeaders(Http::RequestHeaderMap &headers,
   return Http::FilterHeadersStatus::StopIteration;
 }
 
+
+Http::FilterHeadersStatus 
+AWSLambdaFilter::encodeHeaders(Http::ResponseHeaderMap &headers, bool ) {
+
+  if (!headers.get(AWSLambdaHeaderNames::get().FunctionError).empty()){
+    // We treat upstream errors as if it was any other upstream error
+    headers.setStatus(504);
+    return Http::FilterHeadersStatus::Continue;
+  }
+  return Http::FilterHeadersStatus::StopIteration;
+}
+
+Http::FilterDataStatus AWSLambdaFilter::encodeData(Buffer::Instance &,
+                                                        bool ) {
+  return Http::FilterDataStatus::Continue;
+}
+
+Http::FilterTrailersStatus
+AWSLambdaFilter::encodeTrailers(Http::ResponseTrailerMap &) {
+  return Http::FilterTrailersStatus::StopIteration;
+}
+
 void AWSLambdaFilter::onSuccess(
     std::shared_ptr<const Envoy::Extensions::Common::Aws::Credentials>
         credentials) {
@@ -151,7 +174,7 @@ void AWSLambdaFilter::onSuccess(
                                        RcDetails::get().CredentialsNotFound);
     return;
   }
-
+ 
   aws_authenticator_.init(access_key, secret_key, session_token);
 
   request_headers_->setReferenceMethod(Http::Headers::get().MethodValues.Post);
@@ -223,7 +246,7 @@ AWSLambdaFilter::decodeTrailers(Http::RequestTrailerMap &) {
 }
 
 void AWSLambdaFilter::lambdafy() {
-
+  
   handleDefaultBody();
 
   const std::string &invocation_type =

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -55,10 +55,13 @@ public:
   }
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap &headers,
                                           bool end_stream) override;
-  Http::FilterDataStatus encodeData(Buffer::Instance &data,
-                                    bool end_stream) override;
-  Http::FilterTrailersStatus
-  encodeTrailers(Http::ResponseTrailerMap &trailers) override;
+  Http::FilterDataStatus encodeData(Buffer::Instance &, bool ) override{
+    return Http::FilterDataStatus::Continue;
+  }
+
+  Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap &) override{
+    return Http::FilterTrailersStatus::Continue;
+  }
   Http::FilterMetadataStatus encodeMetadata(Http::MetadataMap &) override {
     return Http::FilterMetadataStatus::Continue;
   }

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <string>
 
+#include "envoy/server/filter_config.h"
 #include "envoy/http/filter.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -21,7 +22,7 @@ namespace AwsLambda {
  * A filter to make calls to AWS Lambda. Note that as a functional filter,
  * it expects retrieveFunction to be called before decodeHeaders.
  */
-class AWSLambdaFilter : public Http::StreamDecoderFilter,
+class AWSLambdaFilter : public Http::StreamFilter,
                         StsConnectionPool::Context::Callbacks,
                         Logger::Loggable<Logger::Id::filter> {
 public:
@@ -46,6 +47,24 @@ public:
       Http::StreamDecoderFilterCallbacks &decoder_callbacks) override {
     decoder_callbacks_ = &decoder_callbacks;
   }
+
+   // Http::StreamEncoderFilter
+  Http::FilterHeadersStatus
+  encode100ContinueHeaders(Http::ResponseHeaderMap &) override {
+    return Http::FilterHeadersStatus::Continue;
+  }
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap &headers,
+                                          bool end_stream) override;
+  Http::FilterDataStatus encodeData(Buffer::Instance &data,
+                                    bool end_stream) override;
+  Http::FilterTrailersStatus
+  encodeTrailers(Http::ResponseTrailerMap &trailers) override;
+  Http::FilterMetadataStatus encodeMetadata(Http::MetadataMap &) override {
+    return Http::FilterMetadataStatus::Continue;
+  }
+
+  void setEncoderFilterCallbacks(
+      Http::StreamEncoderFilterCallbacks &) override {  };
 
   void
   onSuccess(std::shared_ptr<const Envoy::Extensions::Common::Aws::Credentials>

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter_config_factory.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter_config_factory.cc
@@ -29,7 +29,7 @@ AWSLambdaFilterConfigFactory::createFilterFactoryFromProtoTyped(
 
   return
       [&context, config](Http::FilterChainFactoryCallbacks &callbacks) -> void {
-        callbacks.addStreamDecoderFilter(std::make_shared<AWSLambdaFilter>(
+        callbacks.addStreamFilter(std::make_shared<AWSLambdaFilter>(
             context.clusterManager(), context.api(), config));
       };
 }

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -414,7 +414,7 @@ TEST_F(AWSLambdaFilterTest, UpstreamErrorSetTo504) {
     {":path", "/path"}};
   auto res = filter_->encodeHeaders(response_headers, true);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, res);
-  EXPECT_EQ(response_headers.get_(":status"), "504");
+  EXPECT_EQ(response_headers.getStatusValue(), "504");
   
 }
 

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -402,6 +402,22 @@ TEST_F(AWSLambdaFilterTest, NoCredsAvailable) {
             filter_->decodeHeaders(headers, true));
 }
 
+TEST_F(AWSLambdaFilterTest, UpstreamErrorSetTo504) {
+  setup_func();
+
+  Http::TestResponseHeaderMapImpl response_headers{
+    {"content-type", "test"},
+    {":method", "GET"},
+    {":authority", "www.solo.io"},
+    {":status", "200"},
+    {"x-amz-function-error", "fakerr"},
+    {":path", "/path"}};
+  auto res = filter_->encodeHeaders(response_headers, true);
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, res);
+  EXPECT_EQ(response_headers.get_(":status"), "504");
+  
+}
+
 } // namespace AwsLambda
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
On 200 response with fxn error such as with timeouts treat it as a 504 and pass the 504 along to the caller from downstream. 