### PR TITLE
Add file so go can include .protos from this repo

### DIFF
--- a/changelog/v1.20.0-patch3/go-dep.yaml
+++ b/changelog/v1.20.0-patch3/go-dep.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/533
+  resolvesIssue: false
+  description: >
+    Adds a no-op go file that allows other projects to require envoy-gloo 
+    via go.mod, for the sake of pulling in the .proto files from the 
+    specific tag or commit maintained in go.mod 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+// Note: this repo does not provide any real go code, but is a module nevertheless
+// so that other go projects can pull in the .proto files through the module path
+module github.com/solo-io/envoy-gloo
+
+go 1.17

--- a/test/build/go_build_test.go
+++ b/test/build/go_build_test.go
@@ -1,0 +1,8 @@
+package go_build_test
+
+import "testing"
+
+func TestNoop(t *testing.T) {
+	// This is just noop that can be referenced as a go dependency by other 
+	// projects for the sake of pulling in the .protos
+}


### PR DESCRIPTION
The go file in this PR doesn't _do_ anything other than exist.  This allows other projects to [require it via go.mod](https://github.com/solo-io/gloo-mesh-enterprise/blob/ba8d99a9414ea10a071a0c67628c32974e0acb3b/go.mod#L73), for the sake of pulling in the .proto files from the specific tag or commit maintained in `go.mod`.  

(Note, this isn't a new pattern.  [github.com/envoyproxy/data-plane-api/test/build/go_build_test.go](https://github.com/envoyproxy/data-plane-api/blob/main/test/build/go_build_test.go) exists to serve this purpose as well.  It's referenced in [solo-io/gloo-mesh-enterprise/go.mod](https://github.com/solo-io/gloo-mesh-enterprise/blob/652326a3395156e1a7978f8fb1bba1216d902581/go.mod#L17), and survives `go mod tidy` via a [no-op import](https://github.com/solo-io/gloo-mesh-enterprise/blob/ae402ea27cd8503630933061387d068c27af4252/enterprise-networking/ci/tools.go#L10))