### PR TITLE
WIP: Throwaway/lambda sts chains

### DIFF
--- a/source/extensions/filters/http/aws_lambda/BUILD
+++ b/source/extensions/filters/http/aws_lambda/BUILD
@@ -121,7 +121,22 @@ envoy_cc_library(
 envoy_cc_library(
     name = "sts_fetcher_lib",
     srcs = ["sts_fetcher.cc"],
-    hdrs = ["sts_fetcher.h", "sts_status.h"],
+    hdrs = ["sts_fetcher.h", "sts_status.h", "sts_response_parser.h"],
+    repository = "@envoy",
+    deps = [
+        ":sts_chained_fetcher_lib",
+        "@envoy//source/common/common:minimal_logger_lib",
+        "@envoy//source/common/config:datasource_lib",
+        "@envoy//source/common/protobuf:utility_lib",
+        "@envoy//source/extensions/common/aws:credentials_provider_interface",
+        "//api/envoy/config/filter/http/aws_lambda/v2:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
+    name = "sts_chained_fetcher_lib",
+    srcs = ["sts_chained_fetcher.cc"],
+    hdrs = ["sts_chained_fetcher.h", "sts_status.h"],
     repository = "@envoy",
     deps = [
         "@envoy//source/common/common:minimal_logger_lib",

--- a/source/extensions/filters/http/aws_lambda/BUILD
+++ b/source/extensions/filters/http/aws_lambda/BUILD
@@ -17,6 +17,7 @@ envoy_cc_library(
     external_deps = ["ssl"],
     repository = "@envoy",
     deps = [
+        "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//envoy/buffer:buffer_interface",
         "@envoy//envoy/http:header_map_interface",
         "@envoy//source/common/common:assert_lib",
@@ -25,6 +26,7 @@ envoy_cc_library(
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/http:utility_lib",
         "@envoy//source/common/common:base64_lib",
+        
     ],
 )
 
@@ -121,7 +123,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "sts_fetcher_lib",
     srcs = ["sts_fetcher.cc"],
-    hdrs = ["sts_fetcher.h", "sts_status.h", "sts_response_parser.h"],
+    hdrs = ["sts_fetcher.h", "sts_status.h"],
     repository = "@envoy",
     deps = [
         ":sts_chained_fetcher_lib",
@@ -136,13 +138,16 @@ envoy_cc_library(
 envoy_cc_library(
     name = "sts_chained_fetcher_lib",
     srcs = ["sts_chained_fetcher.cc"],
-    hdrs = ["sts_chained_fetcher.h", "sts_status.h"],
+    hdrs = ["sts_chained_fetcher.h", "sts_status.h",  "sts_response_parser.h"],
     repository = "@envoy",
     deps = [
+        
         "@envoy//source/common/common:minimal_logger_lib",
+        ":aws_authenticator_lib",
         "@envoy//source/common/config:datasource_lib",
         "@envoy//source/common/protobuf:utility_lib",
         "@envoy//source/extensions/common/aws:credentials_provider_interface",
+        
         "//api/envoy/config/filter/http/aws_lambda/v2:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.h
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.h
@@ -37,6 +37,7 @@ typedef std::set<Http::LowerCaseString, LowerCaseStringCompareFunc> HeaderList;
 class AwsAuthenticator {
 public:
   AwsAuthenticator(TimeSource &time_source);
+  AwsAuthenticator(TimeSource &time_source, const std::string *service);
 
   ~AwsAuthenticator();
 

--- a/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.cc
@@ -1,0 +1,154 @@
+#include "source/extensions/filters/http/aws_lambda/sts_chained_fetcher.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/enum_to_int.h"
+#include "source/common/common/regex.h"
+#include "source/common/http/headers.h"
+#include "source/common/http/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AwsLambda {
+
+namespace {
+
+class StsChainedFetcherImpl : public StsChainedFetcher,
+                       public Logger::Loggable<Logger::Id::aws>,
+                       public Http::AsyncClient::Callbacks {
+public:
+  StsChainedFetcherImpl(Upstream::ClusterManager &cm, Api::Api &api, 
+                                          const absl::string_view base_role_arn)
+      : cm_(cm), api_(api), base_role_arn_(base_role_arn) {
+    ENVOY_LOG(trace, "{}", __func__);
+  }
+
+  ~StsChainedFetcherImpl() override { cancel(); }
+
+  void cancel() override {
+    if (request_ && !complete_) {
+      request_->cancel();
+      ENVOY_LOG(debug, "assume role with token [uri = {}]: canceled",
+                uri_->uri());
+    }
+    reset();
+  }
+
+  void fetch(const envoy::config::core::v3::HttpUri &uri,
+             const  absl::string_view role_arn,
+             const  absl::string_view webtoken_response,
+             StsChainedFetcher::ChainedCallback *callback) override {
+    ENVOY_LOG(trace, "{}", __func__);
+    
+    ASSERT(!webtoken_response.empty());
+    complete_ = false;
+    callback_ = callback;
+    uri_ = &uri;
+    set_role(role_arn);
+
+
+    // Check if cluster is configured, fail the request if not.
+    // Otherwise cm_.httpAsyncClientForCluster will throw exception.
+    const auto thread_local_cluster = cm_.getThreadLocalCluster(uri.cluster());
+    
+    if (thread_local_cluster == nullptr) {
+      ENVOY_LOG(error,
+                "{}: chained assume role [uri = {}] failed: [cluster = {}] "
+                "is not configured",
+                __func__, uri.uri(), uri.cluster());
+      complete_ = true;
+      callback_->onChainedFailure(CredentialsFailureStatus::ClusterNotFound);
+      reset();
+      return;
+    }
+
+
+    //TODO: REMOVE THIS TESTING ONLY
+    if (true){
+      // callback_->onChainedSuccess(webtoken_response);
+      return;
+    }
+
+    Http::RequestMessagePtr message = Http::Utility::prepareHeaders(uri);
+    message->headers().setReferenceMethod(
+        Http::Headers::get().MethodValues.Post);
+    message->headers().setContentType(
+        Http::Headers::get().ContentTypeValues.FormUrlEncoded);
+    const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         api_.timeSource().systemTime().time_since_epoch())
+                         .count();
+    const std::string body =
+        fmt::format(StsChainedFormatString, role_arn, now);
+    message->body().add(body);
+    ENVOY_LOG(debug, "assume role with token from [uri = {}]: start",
+              uri_->uri());
+    auto options = Http::AsyncClient::RequestOptions().setTimeout(
+        std::chrono::milliseconds(
+            DurationUtil::durationToMilliseconds(uri.timeout())));
+    request_ = thread_local_cluster->httpAsyncClient().send(std::move(message), *this, options);
+  }
+
+  // HTTP async receive methods
+  void onSuccess(const Http::AsyncClient::Request &,
+                 Http::ResponseMessagePtr &&response) override {
+    complete_ = true;
+   
+   if (response->body().length() > 0) {
+      const auto len = response->body().length();
+        const auto body = absl::string_view(
+            static_cast<char *>(response->body().linearize(len)), len);
+
+     ENVOY_LOG(debug, "{}: chained ", body);
+   }
+
+
+    callback_->onChainedFailure(CredentialsFailureStatus::Network);
+    
+    reset();
+  }
+
+  void onFailure(const Http::AsyncClient::Request &,
+                 Http::AsyncClient::FailureReason reason) override {
+    complete_ = true;
+    ENVOY_LOG(debug, "{}: chained assume role [uri = {}]: network error {}",
+              __func__, uri_->uri(), enumToInt(reason));
+    callback_->onChainedFailure(CredentialsFailureStatus::Network);
+    
+    reset();
+  }
+
+  void onBeforeFinalizeUpstreamSpan(Tracing::Span &,
+                                    const Http::ResponseHeaderMap *) override {}
+
+private:
+  Upstream::ClusterManager &cm_;
+  Api::Api &api_;
+  const absl::string_view base_role_arn_;
+  bool complete_{};
+  StsChainedFetcher::ChainedCallback *callback_{};
+  const envoy::config::core::v3::HttpUri *uri_{};
+  Http::AsyncClient::Request *request_{};
+  absl::string_view role_arn_;
+
+  // work around having consts being passed around.
+  void set_role(const absl::string_view role_arn){
+    role_arn_ = role_arn;
+  }
+
+  void reset() {
+    request_ = nullptr;
+    callback_ = nullptr;
+    uri_ = nullptr;
+  }
+};
+} // namespace
+
+StsChainedFetcherPtr StsChainedFetcher::create(Upstream::ClusterManager &cm, Api::Api &api,
+                                             const absl::string_view base_role_arn) {
+  return std::make_unique<StsChainedFetcherImpl>(cm, api, base_role_arn);
+}
+
+} // namespace AwsLambda
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.cc
@@ -1,10 +1,16 @@
 #include "source/extensions/filters/http/aws_lambda/sts_chained_fetcher.h"
 
+#include "source/extensions/filters/http/aws_lambda/sts_response_parser.h"
+
+#include "source/extensions/filters/http/aws_lambda/aws_authenticator.h"
+
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/enum_to_int.h"
 #include "source/common/common/regex.h"
-#include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
+#include "source/common/http/headers.h"
+
+
 
 namespace Envoy {
 namespace Extensions {
@@ -19,7 +25,9 @@ class StsChainedFetcherImpl : public StsChainedFetcher,
 public:
   StsChainedFetcherImpl(Upstream::ClusterManager &cm, Api::Api &api, 
                                           const absl::string_view base_role_arn)
-      : cm_(cm), api_(api), base_role_arn_(base_role_arn) {
+      : cm_(cm), api_(api), base_role_arn_(base_role_arn) ,
+       aws_authenticator_(api.timeSource(), 
+       &AWSStsHeaderNames::get().Service){
     ENVOY_LOG(trace, "{}", __func__);
   }
 
@@ -36,16 +44,15 @@ public:
 
   void fetch(const envoy::config::core::v3::HttpUri &uri,
              const  absl::string_view role_arn,
-             const  absl::string_view webtoken_response,
+             const std::string access_key, 
+             const std::string secret_key,
+             const std::string session_token,
              StsChainedFetcher::ChainedCallback *callback) override {
     ENVOY_LOG(trace, "{}", __func__);
-    
-    ASSERT(!webtoken_response.empty());
     complete_ = false;
     callback_ = callback;
     uri_ = &uri;
     set_role(role_arn);
-
 
     // Check if cluster is configured, fail the request if not.
     // Otherwise cm_.httpAsyncClientForCluster will throw exception.
@@ -53,23 +60,17 @@ public:
     
     if (thread_local_cluster == nullptr) {
       ENVOY_LOG(error,
-                "{}: chained assume role [uri = {}] failed: [cluster = {}] "
-                "is not configured",
-                __func__, uri.uri(), uri.cluster());
+       "{}: chained assume role [uri = {}] failed: [cluster = {}] "
+        "is not configured", __func__, uri.uri(), uri.cluster());
       complete_ = true;
       callback_->onChainedFailure(CredentialsFailureStatus::ClusterNotFound);
       reset();
       return;
     }
 
-
-    //TODO: REMOVE THIS TESTING ONLY
-    if (true){
-      // callback_->onChainedSuccess(webtoken_response);
-      return;
-    }
-
     Http::RequestMessagePtr message = Http::Utility::prepareHeaders(uri);
+    // Post with form-encoded works aligns with lambda call implementation
+    // If need be this can be converted to GET with query-params
     message->headers().setReferenceMethod(
         Http::Headers::get().MethodValues.Post);
     message->headers().setContentType(
@@ -77,14 +78,25 @@ public:
     const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
                          api_.timeSource().systemTime().time_since_epoch())
                          .count();
-    const std::string body =
-        fmt::format(StsChainedFormatString, role_arn, now);
+    const std::string body = fmt::format(StsChainedFormatString, role_arn, now);
+
     message->body().add(body);
-    ENVOY_LOG(debug, "assume role with token from [uri = {}]: start",
-              uri_->uri());
+
     auto options = Http::AsyncClient::RequestOptions().setTimeout(
-        std::chrono::milliseconds(
-            DurationUtil::durationToMilliseconds(uri.timeout())));
+                          std::chrono::milliseconds(
+                          DurationUtil::durationToMilliseconds(uri.timeout())));
+ 
+    aws_authenticator_.init(&access_key, &secret_key, &session_token);
+    aws_authenticator_.updatePayloadHash(message->body());
+
+    ENVOY_LOG(debug, " chained auth payload {}", message->body().length());
+
+    // TODO(nfudenberg) dont do this silly dereference if possible
+    auto& hdrs = message->headers();
+    // TODO(nfudenberg) allow for Region this to be overridable. DefaultRegion is gauranteed to be available 
+    // Configured override region may be faster.
+    aws_authenticator_.sign(&hdrs, HeadersToSign, DefaultRegion);
+
     request_ = thread_local_cluster->httpAsyncClient().send(std::move(message), *this, options);
   }
 
@@ -95,15 +107,39 @@ public:
    
    if (response->body().length() > 0) {
       const auto len = response->body().length();
-        const auto body = absl::string_view(
+      const auto body = absl::string_view(
             static_cast<char *>(response->body().linearize(len)), len);
 
-     ENVOY_LOG(debug, "{}: chained ", body);
+     ENVOY_LOG(debug, "{}: chained body ", body);
+      // CONSIDER: moving this to a better function loction
+      // ripped from sts_connection
+      #define GET_PARAM(X)                                                         \
+      std::string X;                                                               \
+      {                                                                            \
+        std::match_results<absl::string_view::const_iterator> matched;             \
+        bool result = std::regex_search(body.begin(), body.end(), matched,         \
+                                        DUPEStsResponseRegex::get().regex_##X);    \
+        if (!result || !(matched.size() != 1)) {                                   \
+          ENVOY_LOG(trace, "response body did not contain " #X);                   \
+          callback_-> onChainedFailure(CredentialsFailureStatus::InvalidSts);      \
+          return;                                                                  \
+        }                                                                          \
+        const auto &sub_match = matched[1];                                        \
+        decltype(X) matched_sv(sub_match.first, sub_match.length());               \
+        X = std::move(matched_sv);                                                 \
+      }
+
+      GET_PARAM(access_key);
+      GET_PARAM(secret_key);
+      GET_PARAM(session_token);
+      GET_PARAM(expiration);
+      callback_->onChainedSuccess(access_key, secret_key, session_token, expiration);
+   }else{
+      callback_->onChainedFailure(CredentialsFailureStatus::Network);
    }
 
 
-    callback_->onChainedFailure(CredentialsFailureStatus::Network);
-    
+
     reset();
   }
 
@@ -129,11 +165,31 @@ private:
   const envoy::config::core::v3::HttpUri *uri_{};
   Http::AsyncClient::Request *request_{};
   absl::string_view role_arn_;
+  AwsAuthenticator aws_authenticator_;
+
+
+  class AWSStsHeaderValues {
+  public:
+    const std::string Service{"sts"};
+     const Http::LowerCaseString DateHeader{"x-amz-date"};
+    const Http::LowerCaseString FunctionError{"x-amz-function-error"};
+  };
+  typedef ConstSingleton<AWSStsHeaderValues> AWSStsHeaderNames;
+  const HeaderList HeadersToSign =
+    AwsAuthenticator::createHeaderToSign(
+        { 
+          Http::Headers::get().ContentType,
+        AWSStsHeaderNames::get().DateHeader,
+        Http::Headers::get().HostLegacy}
+         );
 
   // work around having consts being passed around.
   void set_role(const absl::string_view role_arn){
     role_arn_ = role_arn;
   }
+
+  
+  const std::string DefaultRegion = "us-east-1";
 
   void reset() {
     request_ = nullptr;

--- a/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.h
+++ b/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "envoy/api/api.h"
+#include "envoy/common/pure.h"
+#include "envoy/config/core/v3/http_uri.pb.h"
+#include "envoy/upstream/cluster_manager.h"
+
+#include "source/extensions/common/aws/credentials_provider.h"
+#include "source/extensions/filters/http/aws_lambda/sts_status.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AwsLambda {
+
+namespace {
+constexpr char StsChainedFormatString[] =
+    "Action=AssumeRole&RoleArn={}&RoleSessionName={}&"
+    "<TODOSIG>&Version=2011-06-15";
+
+} // namespace
+
+
+class StsChainedFetcher;
+using StsChainedFetcherPtr = std::unique_ptr<StsChainedFetcher>;
+
+/**
+ * StsChainedFetcher interface can be used to retrieve STS credentials 
+ * for a new account if you already have assumed a role.
+ * An instance of this interface is designed to retrieve one set of credentials
+ * at a time and is scoped to a given role.
+ * Does not currently support multi-chaining.
+ */
+class StsChainedFetcher {
+public:
+  virtual ~StsChainedFetcher() = default;
+
+  class ChainedCallback {
+  public:
+    virtual ~ChainedCallback() = default;
+
+    /**
+     * Called on successful request
+     *
+     * @param body the request body
+     */
+    virtual void onChainedSuccess(const std::string access_key, 
+   const std::string secret_key, 
+   const std::string session_token, 
+   const std::string  expiration) PURE;
+
+    /**
+     * Called on completion of a failed request.
+     *
+     * @param status the status of the request.
+     */
+    virtual void onChainedFailure(CredentialsFailureStatus status) PURE;
+  };
+
+class Callbacks {
+  public:
+    virtual ~Callbacks() = default;
+
+    /**
+     * Called on successful request
+     *
+     * @param body the request body
+     */
+    virtual void onSuccess(const absl::string_view body) PURE;
+
+    /**
+     * Called on completion of a failed request.
+     *
+     * @param status the status of the request.
+     */
+    virtual void onFailure(CredentialsFailureStatus status) PURE;
+  };
+
+
+  /*
+   * Cancel any in-flight request.
+   */
+  virtual void cancel() PURE;
+
+  /*
+   * At most one outstanding request may be in-flight,
+   * i.e. from the invocation of `fetch()` until either
+   * a callback or `cancel()` is invoked, no
+   * additional `fetch()` may be issued.
+   * @param uri the uri to retrieve the jwks from.
+   * @param role_arn the role_arn which of the role to assume
+   * @param success the cb called on successful role assumption
+   * @param failure the cb called on failed role assumption
+   */
+  virtual void fetch(const envoy::config::core::v3::HttpUri &uri,
+                     const absl::string_view role_arn,
+                       const  absl::string_view webtoken_response,
+                     StsChainedFetcher::ChainedCallback *callback)  PURE;
+
+  /*
+   * Factory method for creating a StsChainedFetcher.
+   * @param cm the cluster manager to use during Sts retrieval
+   * @param api the api instance
+   * @return a StsChainedFetcher instance
+   */
+  static StsChainedFetcherPtr create(Upstream::ClusterManager &cm, Api::Api &api,
+                                        const absl::string_view base_role_arn );
+};
+
+} // namespace AwsLambda
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.h
+++ b/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.h
@@ -5,6 +5,9 @@
 #include "envoy/config/core/v3/http_uri.pb.h"
 #include "envoy/upstream/cluster_manager.h"
 
+
+#include "source/extensions/filters/http/aws_lambda/sts_chained_fetcher.h"
+#include "source/extensions/filters/http/aws_lambda/aws_authenticator.h"
 #include "source/extensions/common/aws/credentials_provider.h"
 #include "source/extensions/filters/http/aws_lambda/sts_status.h"
 
@@ -16,7 +19,7 @@ namespace AwsLambda {
 namespace {
 constexpr char StsChainedFormatString[] =
     "Action=AssumeRole&RoleArn={}&RoleSessionName={}&"
-    "<TODOSIG>&Version=2011-06-15";
+    "Version=2011-06-15";
 
 } // namespace
 
@@ -27,7 +30,7 @@ using StsChainedFetcherPtr = std::unique_ptr<StsChainedFetcher>;
 /**
  * StsChainedFetcher interface can be used to retrieve STS credentials 
  * for a new account if you already have assumed a role.
- * An instance of this interface is designed to retrieve one set of credentials
+ * An instance of this interface is designed to retrieve one set of credentialssess
  * at a time and is scoped to a given role.
  * Does not currently support multi-chaining.
  */
@@ -57,56 +60,58 @@ public:
     virtual void onChainedFailure(CredentialsFailureStatus status) PURE;
   };
 
-class Callbacks {
-  public:
-    virtual ~Callbacks() = default;
+  class Callbacks {
+    public:
+      virtual ~Callbacks() = default;
 
-    /**
-     * Called on successful request
-     *
-     * @param body the request body
-     */
-    virtual void onSuccess(const absl::string_view body) PURE;
+      /**
+      * Called on successful request
+      *
+      * @param body the request body
+      */
+      virtual void onSuccess(const absl::string_view body) PURE;
 
-    /**
-     * Called on completion of a failed request.
-     *
-     * @param status the status of the request.
-     */
-    virtual void onFailure(CredentialsFailureStatus status) PURE;
+      /**
+      * Called on completion of a failed request.
+      *
+      * @param status the status of the request.
+      */
+      virtual void onFailure(CredentialsFailureStatus status) PURE;
   };
 
 
-  /*
-   * Cancel any in-flight request.
-   */
-  virtual void cancel() PURE;
+    /*
+    * Cancel any in-flight request.
+    */
+    virtual void cancel() PURE;
 
-  /*
-   * At most one outstanding request may be in-flight,
-   * i.e. from the invocation of `fetch()` until either
-   * a callback or `cancel()` is invoked, no
-   * additional `fetch()` may be issued.
-   * @param uri the uri to retrieve the jwks from.
-   * @param role_arn the role_arn which of the role to assume
-   * @param success the cb called on successful role assumption
-   * @param failure the cb called on failed role assumption
-   */
-  virtual void fetch(const envoy::config::core::v3::HttpUri &uri,
-                     const absl::string_view role_arn,
-                       const  absl::string_view webtoken_response,
-                     StsChainedFetcher::ChainedCallback *callback)  PURE;
+    /*
+    * At most one outstanding request may be in-flight,
+    * i.e. from the invocation of `fetch()` until either
+    * a callback or `cancel()` is invoked, no
+    * additional `fetch()` may be issued.
+    * @param uri the uri to retrieve the jwks from.
+    * @param role_arn the role_arn which of the role to assume
+    * @param success the cb called on successful role assumption
+    * @param failure the cb called on failed role assumption
+    */
+    virtual void fetch(const envoy::config::core::v3::HttpUri &uri,
+                      const absl::string_view role_arn,
+                        const std::string access_key, 
+                      const std::string secret_key,
+                      const std::string session_token,
+                      StsChainedFetcher::ChainedCallback *callback)  PURE;
 
-  /*
-   * Factory method for creating a StsChainedFetcher.
-   * @param cm the cluster manager to use during Sts retrieval
-   * @param api the api instance
-   * @return a StsChainedFetcher instance
-   */
-  static StsChainedFetcherPtr create(Upstream::ClusterManager &cm, Api::Api &api,
-                                        const absl::string_view base_role_arn );
-};
-
+    /*
+    * Factory method for creating a StsChainedFetcher.
+    * @param cm the cluster manager to use during Sts retrieval
+    * @param api the api instance
+    * @return a StsChainedFetcher instance
+    */
+    static StsChainedFetcherPtr create(Upstream::ClusterManager &cm, Api::Api &api,
+                                          const absl::string_view base_role_arn );
+  };
+ 
 } // namespace AwsLambda
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.h
+++ b/source/extensions/filters/http/aws_lambda/sts_chained_fetcher.h
@@ -30,9 +30,13 @@ using StsChainedFetcherPtr = std::unique_ptr<StsChainedFetcher>;
 /**
  * StsChainedFetcher interface can be used to retrieve STS credentials 
  * for a new account if you already have assumed a role.
- * An instance of this interface is designed to retrieve one set of credentialssess
+ * An instance of this interface is designed to retrieve one set of credentials
  * at a time and is scoped to a given role.
  * Does not currently support multi-chaining.
+ * A chained role assumption is not allowed to be for more than 1 hour.
+ * So we for now do not change the default 1 hour assumption.
+ * https://docs.aws.amazon.com
+ * /IAM/latest/UserGuide/id_roles_terms-and-concepts.html
  */
 class StsChainedFetcher {
 public:
@@ -108,8 +112,8 @@ public:
     * @param api the api instance
     * @return a StsChainedFetcher instance
     */
-    static StsChainedFetcherPtr create(Upstream::ClusterManager &cm, Api::Api &api,
-                                          const absl::string_view base_role_arn );
+    static StsChainedFetcherPtr create(Upstream::ClusterManager &cm, 
+                         Api::Api &api, const absl::string_view base_role_arn );
   };
  
 } // namespace AwsLambda

--- a/source/extensions/filters/http/aws_lambda/sts_credentials_provider.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_credentials_provider.cc
@@ -29,7 +29,7 @@ public:
 
   StsConnectionPool::Context *
   find(const absl::optional<std::string> &role_arn_arg,
-       StsConnectionPool::Context::Callbacks *callbacks) override;
+        StsConnectionPool::Context::Callbacks *callbacks) override;
 
   void setWebToken(std::string_view web_token) override;
 
@@ -126,7 +126,7 @@ StsConnectionPool::Context *StsCredentialsProviderImpl::find(
   auto conn_pool =
       connection_pools_
           .emplace(role_arn, conn_pool_factory_->build(
-                                 role_arn, this, StsFetcher::create(cm_, api_)))
+                  role_arn, this, StsFetcher::create(cm_, api_, default_role_arn_)))
           .first;
   // initialize the connection
   conn_pool->second->init(uri_, web_token_);

--- a/source/extensions/filters/http/aws_lambda/sts_credentials_provider.h
+++ b/source/extensions/filters/http/aws_lambda/sts_credentials_provider.h
@@ -33,7 +33,7 @@ public:
   // Lookup credentials cache map.
   virtual StsConnectionPool::Context *
   find(const absl::optional<std::string> &role_arn,
-       StsConnectionPool::Context::Callbacks *callbacks) PURE;
+        StsConnectionPool::Context::Callbacks *callbacks) PURE;
 
   virtual void setWebToken(std::string_view web_token) PURE;
 

--- a/source/extensions/filters/http/aws_lambda/sts_response_parser.h
+++ b/source/extensions/filters/http/aws_lambda/sts_response_parser.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "source/common/common/regex.h"
+#include "source/common/singleton/const_singleton.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AwsLambda {
+
+namespace {
+/*
+ * AssumeRoleWithIdentity returns a set of temporary credentials with a minimum
+ * lifespan of 15 minutes.
+ * https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
+ *
+ * In order to ensure that credentials never expire, we default to 2/3.
+ *
+ * This in combination with the very generous grace period which makes sure the
+ * tokens are refreshed if they have < 5 minutes left on their lifetime. Whether
+ * that lifetime is our prescribed, or from the response itself.
+ */
+constexpr std::chrono::milliseconds DUPE_REFRESH_STS_CREDS =
+    std::chrono::minutes(10);
+
+} // namespace
+
+
+class DUPEStsResponseRegexValues {
+public:
+  DUPEStsResponseRegexValues() {
+
+    // Initialize regex strings, should never fail
+    regex_access_key =
+        Regex::Utility::parseStdRegex("<AccessKeyId>(.*?)</AccessKeyId>");
+    regex_secret_key = Regex::Utility::parseStdRegex(
+        "<SecretAccessKey>(.*?)</SecretAccessKey>");
+    regex_session_token =
+        Regex::Utility::parseStdRegex("<SessionToken>(.*?)</SessionToken>");
+    regex_expiration =
+        Regex::Utility::parseStdRegex("<Expiration>(.*?)</Expiration>");
+  };
+
+  std::regex regex_access_key;
+
+  std::regex regex_secret_key;
+
+  std::regex regex_session_token;
+
+  std::regex regex_expiration;
+};
+
+using DUPEStsResponseRegex = ConstSingleton<DUPEStsResponseRegexValues>;
+
+
+} // namespace AwsLambda
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy
+
+

--- a/test/extensions/filters/http/aws_lambda/BUILD
+++ b/test/extensions/filters/http/aws_lambda/BUILD
@@ -62,6 +62,7 @@ envoy_gloo_cc_test(
     deps = [
         ":aws_mocks",
         "//source/extensions/filters/http/aws_lambda:sts_fetcher_lib",
+        "//source/extensions/filters/http/aws_lambda:sts_chained_fetcher_lib",
         "@envoy//test/extensions/filters/http/common:mock_lib",
         "@envoy//test/test_common:utility_lib",
         "@envoy//test/mocks/server:factory_context_mocks",

--- a/test/extensions/filters/http/aws_lambda/mocks.h
+++ b/test/extensions/filters/http/aws_lambda/mocks.h
@@ -27,7 +27,10 @@ public:
 
 class MockStsFetcherCallbacks : public StsFetcher::Callbacks {
 public:
-  MOCK_METHOD(void, onSuccess, (const absl::string_view body));
+  MOCK_METHOD(void, onSuccess, (const std::string access_key, 
+   const std::string secret_key, 
+   const std::string session_token, 
+   const SystemTime expiration));
   MOCK_METHOD(void, onFailure, (CredentialsFailureStatus status));
 };
 


### PR DESCRIPTION
A sample working implementation that does not deal smartly with refresh of underlying webtoken.
(ie has n-1 extra calls where n is the number of arns that have been used on the instance of envoy since it spun up).

This merge is mainly for comment at this point as we will try to get the connection pool to handle chaining the calls so we can reduce the call count.
If that does not fall within our timeline then there is still additional cleaning to do here (like cleaning anything with the Dupe prefix)

Several TODOs will become future feature tickets that unlike this will not be targeted for backports. 
This namely includes the sts region override in chaining as it requires proto changes.