### PR TITLE
backport(fix(Dockerfile)): pin base image version

### DIFF
--- a/changelog/v1.19.0-patch6/pin-base-image-version.yaml
+++ b/changelog/v1.19.0-patch6/pin-base-image-version.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: >
+    To create a consistent CI, adjust base image of docker build to reference a fixed-in-time version of `frolvlad/alpine-glibc`, rather than simply "latest" 

--- a/changelog/validation.yaml
+++ b/changelog/validation.yaml
@@ -1,4 +1,5 @@
 relaxSemverValidation: true
 allowedLabels:
+  - patch
   - rc
   - beta 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,7 @@
 # This file was inspired by envoy Dockerfile:
 # https://github.com/envoyproxy/envoy/blob/445a67344ffda0c8828c8e438e463fcaa7878434/ci/Dockerfile-envoy-alpine
 
-FROM frolvlad/alpine-glibc
+FROM frolvlad/alpine-glibc@sha256:7b5e8e727246ea48bee1690e30f3fe35925ed9e437f87206870b2ba54fef833f
 
 ENV loglevel=info
 


### PR DESCRIPTION
We found that `gloo` OSS has been failing to deploy using `docker compose` since release 1.10.9.  These failures started with the introduction of  https://github.com/solo-io/envoy-gloo/commit/d3e4e3df7b6e024d8963866ef882911f528b667f, which was (for all intents and purposes) a no-op.  Poking around/testing found that [frolvlad/alpine-glibc](https://hub.docker.com/r/frolvlad/alpine-glibc/) updated their `:latest` tag _just_ around the same time frame as we built our failing release.  This PR pins the docker version to what it was _before_ the failures began (and solves said failures).

A couple of caveats:
* this is introducing a gradual drift between what we're using and whatever `frolvlad/alpine-glibc` chooses is their `:latest`.  Not a huge loss, I think, for the upside of consistent CI
* envoy itself [no longer uses said alpine image during their build process](https://github.com/envoyproxy/envoy/commit/bdd22a65b5f20d79704f27e30bf39302440118bc)
* the failure this is fixing was not "everywhere".  It only occurred in specific deployment types.  For example, it passed our CI (kind), but failed docker-compose.  To rectify this, tests will be added in `gloo`

related https://github.com/solo-io/gloo/issues/5980