### PR TITLE
bazel: Bump envoy-gloo to 1.19.5 for cve pickups

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,8 +1,8 @@
 REPOSITORY_LOCATIONS = dict(
-    # envoy-fork 1.19.0-cve0222-rc1, commit: https://github.com/solo-io/envoy-fork/commit/8930222c787a2453c581a0a19e1054b09a918b6c
+    # envoy 1.19.5 https://github.com/envoyproxy/envoy/releases/tag/v1.19.5
     envoy = dict(
-        commit = "8930222c787a2453c581a0a19e1054b09a918b6c",
-        remote = "https://github.com/solo-io/envoy-fork",
+        commit = "fccfb7d2cf663d1af898d1df076a81225d87b790",
+        remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(
         commit = "4c0ee3a46c0bbb279b0849e5a659e52684a37a98",

--- a/changelog/v1.19.5-patch1/bump-envoy.yaml
+++ b/changelog/v1.19.5-patch1/bump-envoy.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    description: Update envoy to 1.19.5 for CVE-2022-29225 CVE-2022-29224  CVE-2022-29226 CVE-2022-29228 CVE-2022-29227
+    dependencyOwner: envoyproxy
+    dependencyRepo: envoy
+    dependencyTag: fccfb7d2cf663d1af898d1df076a81225d87b790


### PR DESCRIPTION
Bump to 1.19.5 to pick up the newly released envoy changes to protect against the given cves