### PR TITLE
bazel: Bump envoy-gloo to 1.20.4 for cve pickups

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
-    # envoy 1.20.2, commit: https://github.com/envoyproxy/envoy/releases/tag/v1.20.2
+    # envoy 1.20.2, commit: https://github.com/envoyproxy/envoy/releases/tag/v1.20.4
     envoy = dict(
-        commit = "4aaf9593152c6996b9da384c8918e9ad4f0abd4d",
+        commit = "85e12a3bacff206f56e0ed117d2f4f77ebd7d68d",
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(

--- a/changelog/v1.20.4-patch1/upgrade-envoy.yaml
+++ b/changelog/v1.20.4-patch1/upgrade-envoy.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    description: Update envoy to 1.20.4 for CVE-2022-29225 CVE-2022-29224  CVE-2022-29226 CVE-2022-29228 CVE-2022-29227
+    dependencyOwner: envoyproxy
+    dependencyRepo: envoy

--- a/changelog/v1.20.4-patch1/upgrade-envoy.yaml
+++ b/changelog/v1.20.4-patch1/upgrade-envoy.yaml
@@ -3,3 +3,4 @@ changelog:
     description: Update envoy to 1.20.4 for CVE-2022-29225 CVE-2022-29224  CVE-2022-29226 CVE-2022-29228 CVE-2022-29227
     dependencyOwner: envoyproxy
     dependencyRepo: envoy
+    dependencyTag: 85e12a3bacff206f56e0ed117d2f4f77ebd7d68d


### PR DESCRIPTION
bump to 1.20.4 to pick up the newly released envoy changes to protect against the given cves