### PR TITLE
Manual version pinning

### DIFF
--- a/changelog/v1.20.4-patch2/update-deps.yaml
+++ b/changelog/v1.20.4-patch2/update-deps.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: openssl
+    dependencyRepo: libcrypto1.1
+    dependencyTag: 1.1.1q-r0
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: openssl
+    dependencyRepo: libssl1.1
+    dependencyTag: 1.1.1q-r0

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,8 +8,8 @@ ENV loglevel=info
 RUN apk upgrade --update-cache \
     && apk add dumb-init ca-certificates \
     && apk add --no-cache \
-         'libcrypto1.1>1.1.1q-r0' \
-         'libssl1.1>1.1.1q-r0' \
+    && apk add libcrypto1.1=1.1.1q-r0 \
+    && apk add libssl1.1=1.1.1q-r0 \
     && rm -rf /var/cache/apk/*
 
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,7 +7,11 @@ ENV loglevel=info
 
 RUN apk upgrade --update-cache \
     && apk add dumb-init ca-certificates \
+    && apk add --no-cache \
+         'libcrypto1.1>1.1.1q-r0' \
+         'libssl1.1>1.1.1q-r0' \
     && rm -rf /var/cache/apk/*
+
 
 RUN mkdir -p /etc/envoy
 


### PR DESCRIPTION
Manually pinned vulnerable dependencies to avoid updating alpine to a potentially breaking version as per https://github.com/solo-io/gloo/issues/5980.