### PR TITLE
Update openssl depedencies

### DIFF
--- a/changelog/v1.23.0-patch2/upgrade-openssl-deps.yaml
+++ b/changelog/v1.23.0-patch2/upgrade-openssl-deps.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: openssl
+    dependencyRepo: libcrypto1.1
+    dependencyTag: 1.1.1q-r0
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: openssl
+    dependencyRepo: libssl1.1
+    dependencyTag: 1.1.1q-r0

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,9 +5,16 @@ FROM frolvlad/alpine-glibc@sha256:7b5e8e727246ea48bee1690e30f3fe35925ed9e437f872
 
 ENV loglevel=info
 
-RUN apk upgrade --update-cache \
-    && apk add dumb-init ca-certificates \
-    && rm -rf /var/cache/apk/*
+RUN apk upgrade --update-cache
+RUN apk add dumb-init ca-certificates
+RUN rm -rf /var/cache/apk/*
+
+# Due to https://github.com/solo-io/gloo/issues/5980 we are pinned to the above alpine-glibc base image
+# To prevent CVEs, we must manually specify the appropriate dependencies
+# A preferrable long term solution is to be able to update the base image which should
+# pull in these fixes directly
+RUN apk add --update-cache --upgrade --no-cache 'libcrypto1.1>=1.1.1q-r0'
+RUN apk add --update-cache --upgrade --no-cache 'libssl1.1>=1.1.1q-r0 '
 
 RUN mkdir -p /etc/envoy
 


### PR DESCRIPTION
In support of Gloo PR: https://github.com/solo-io/gloo/pull/6803 which identified the CVEs in the first place.

# Testing
`trivy image --severity HIGH,CRITICAL quay.io/solo-io/envoy-gloo:fc9c9361d0408583ebdfccb2ac98cd2398c91a68` returns no vulnerabilities