### PR TITLE
Enable removing headers in transformations

### DIFF
--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -197,6 +197,8 @@ message TransformationTemplate {
   // existing headers with the same header name, not replace existing ones.
   repeated HeaderToAppend headers_to_append = 10;
 
+  repeated string headers_to_remove = 11;
+
   // Determines the type of transformation to apply to the request/response body
   oneof body_transformation {
     // Apply a template to the body

--- a/changelog/v1.23.0-patch2/add_headers_to_remove.yaml
+++ b/changelog/v1.23.0-patch2/add_headers_to_remove.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Adds a `header_to_remove` field to the transformation filter plugin
+    issueLink: https://github.com/solo-io/gloo/issues/6539
+    resolvesIssue: False

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -94,6 +94,7 @@ private:
   std::vector<std::pair<std::string, Extractor>> extractors_;
   std::vector<std::pair<Http::LowerCaseString, inja::Template>> headers_;
   std::vector<std::pair<Http::LowerCaseString, inja::Template>> headers_to_append_;
+  std::vector<Http::LowerCaseString> headers_to_remove_;
   std::vector<DynamicMetadataValue> dynamic_metadata_;
   std::unordered_map<std::string, std::string> environ_;
 


### PR DESCRIPTION
* Add a headers_to_remove option to transformation_filter.proto

* Read the headers into `std::vector<Http::LowerCaseString> headers_to_remove_` in the `InjaTransformer` constructor

* Call `header_map.remove()` for each value in `headers_to_remove_` in `InjaTransformer::transform`

* Write a unit test to demonstrate values removed