### PR TITLE
Fix/lambda emplace

### DIFF
--- a/changelog/v1.23.0-patch6/lambda-auth-cleanup.yaml
+++ b/changelog/v1.23.0-patch6/lambda-auth-cleanup.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  description: Check that we can repeatedly use the v4 signing
+  issueLink: https://github.com/solo-io/gloo/issues/6912
+  resolvesIssue: false 

--- a/changelog/v1.23.0-patch7/lambda-auth-cleanup.yaml
+++ b/changelog/v1.23.0-patch7/lambda-auth-cleanup.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  description: Check that we cache auth correctly and handle out of band data updates
+  issueLink: https://github.com/solo-io/gloo/issues/6912
+  resolvesIssue: false

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
@@ -42,6 +42,7 @@ void AwsAuthenticator::init(const std::string *access_key,
   session_token_ = session_token;
   const std::string &secret_key_ref = *secret_key;
   first_key_ = "AWS4" + secret_key_ref;
+  body_sha_ = Sha256{};
 }
 
 AwsAuthenticator::~AwsAuthenticator() {}

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
@@ -35,6 +35,9 @@ AwsAuthenticator::AwsAuthenticator(TimeSource &time_source,
   method_ = &Http::Headers::get().MethodValues.Post;
 }
 
+// init sets up some needed tools for the authenticator 
+// but does not clean state and does not need to be the first
+// call to authenticator. Data may be added prior to this call.
 void AwsAuthenticator::init(const std::string *access_key,
                             const std::string *secret_key,
                             const std::string *session_token) {
@@ -42,14 +45,6 @@ void AwsAuthenticator::init(const std::string *access_key,
   session_token_ = session_token;
   const std::string &secret_key_ref = *secret_key;
   first_key_ = "AWS4" + secret_key_ref;
-}
-
-
-void AwsAuthenticator::resetSHA(){
-  // For usage where auth needs to be reused.
-  // This is not in init as data may be added prior to init being called that
-  // should not be blown away.
-  body_sha_ = Sha256{};
 }
 
 AwsAuthenticator::~AwsAuthenticator() {}

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
@@ -42,7 +42,6 @@ void AwsAuthenticator::init(const std::string *access_key,
   session_token_ = session_token;
   const std::string &secret_key_ref = *secret_key;
   first_key_ = "AWS4" + secret_key_ref;
-  body_sha_ = Sha256{};
 }
 
 

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
@@ -42,6 +42,13 @@ void AwsAuthenticator::init(const std::string *access_key,
   session_token_ = session_token;
   const std::string &secret_key_ref = *secret_key;
   first_key_ = "AWS4" + secret_key_ref;
+}
+
+
+void AwsAuthenticator::resetSHA(){
+  // For usage where auth needs to be reused.
+  // This is not in init as data may be added prior to init being called that
+  // should not be blown away.
   body_sha_ = Sha256{};
 }
 

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.h
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.h
@@ -55,7 +55,6 @@ public:
   static HeaderList
   createHeaderToSign(std::initializer_list<Http::LowerCaseString> headers);
 
-  void resetSHA();
   std::string getBodyHexSha();
 
 private:

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.h
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.h
@@ -55,6 +55,9 @@ public:
   static HeaderList
   createHeaderToSign(std::initializer_list<Http::LowerCaseString> headers);
 
+  void resetSHA();
+  std::string getBodyHexSha();
+
 private:
   // TODO(yuval-k) can I refactor our the friendliness?
   friend class AwsAuthenticatorTest;
@@ -68,7 +71,6 @@ private:
   std::pair<std::string, std::string>
   prepareHeaders(const HeaderList &headers_to_sign);
 
-  std::string getBodyHexSha();
   void fetchUrl();
   std::string computeCanonicalRequestHash(const std::string &request_method,
                                           const std::string &canonical_Headers,

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -81,7 +81,7 @@ public:
   }
   
 
-  const AwsAuthenticator  aws_authenticator() {
+  const AwsAuthenticator  awsAuthenticator() {
     return aws_authenticator_;
   }
 

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -79,6 +79,11 @@ public:
   const AWSLambdaRouteConfig  * functionOnRoute() {
     return function_on_route_;
   }
+  
+
+  const AwsAuthenticator  aws_authenticator() {
+    return aws_authenticator_;
+  }
 
 private:
   static const HeaderList HeadersToSign;

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -80,7 +80,7 @@ public:
     return function_on_route_;
   }
   
-
+  // Used by unit tests to gain access to the authenticator
   const AwsAuthenticator  awsAuthenticator() {
     return aws_authenticator_;
   }

--- a/source/extensions/filters/http/aws_lambda/sts_connection_pool.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_connection_pool.cc
@@ -140,8 +140,7 @@ void StsConnectionPoolImpl::markFailed( CredentialsFailureStatus status) {
 
 void StsConnectionPoolImpl::onSuccess(const absl::string_view body) {
   ASSERT(!body.empty());
-  request_in_flight_ = false;
-
+ 
   // using a macro as we need to return on error
   // TODO(yuval-k): we can use string_view instead of string when we upgrade to
   // newer absl.
@@ -189,6 +188,8 @@ void StsConnectionPoolImpl::onSuccess(const absl::string_view body) {
   // Send result back to Credential Provider to store in cache
   // Report the existence of this credential to any pools that may be waitin
   callbacks_->onResult(result, cache_key_arn_, chained_requests_);
+  request_in_flight_ = false;
+  
   // Send result back to all lambda filter contexts waiting in list
   while (!connection_list_.empty()) {
     connection_list_.back()->callbacks()->onSuccess(result);

--- a/source/extensions/filters/http/aws_lambda/sts_credentials_provider.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_credentials_provider.cc
@@ -84,12 +84,13 @@ void StsCredentialsProviderImpl::setWebToken(std::string_view web_token) {
 }
 
 void StsCredentialsProviderImpl::onResult(
-    std::shared_ptr<const StsCredentials> result, std::string role_arn,
-    std::list<std::string> &chained_requests) {
-    auto updated = credentials_cache_.emplace(role_arn, result);
-    if (updated.second){
-      credentials_cache_[role_arn] = result;
-    }
+  std::shared_ptr<const StsCredentials> result, std::string role_arn,
+  std::list<std::string> &chained_requests) {
+  auto inserted = credentials_cache_.emplace(role_arn, result);
+  // emplace does not override so check if inserted and if not then overrid
+  if (!inserted.second){
+    credentials_cache_[role_arn] = result;
+  }
 
   // kick off any waiting chained assumption roles relying on this credential
   while( !chained_requests.empty()){

--- a/source/extensions/filters/http/aws_lambda/sts_fetcher.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_fetcher.cc
@@ -91,7 +91,7 @@ public:
     message->body().add(body);
     // this call resets the sha so that our authenticator is in a fresh state
     // to be reused.
-    auto aws_authenticator = AwsAuthenticator(api_.timeSource(),
+    AwsAuthenticator aws_authenticator(api_.timeSource(),
                                              &AWSStsHeaderNames::get().Service);
     aws_authenticator.init(&creds->accessKeyId().value(), 
         &creds->secretAccessKey().value(), &creds->sessionToken().value());

--- a/source/extensions/filters/http/aws_lambda/sts_fetcher.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_fetcher.cc
@@ -90,6 +90,8 @@ public:
     // Chained assumption specifics 
     const std::string body = fmt::format(StsChainedFormatString, role_arn, now);
     message->body().add(body);
+    // this call resets the sha as nothing should be added prior to this.
+    aws_authenticator_.resetSHA(); 
     aws_authenticator_.init(&creds->accessKeyId().value(), 
         &creds->secretAccessKey().value(), &creds->sessionToken().value());
     aws_authenticator_.updatePayloadHash(message->body());

--- a/source/extensions/filters/http/aws_lambda/sts_fetcher.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_fetcher.cc
@@ -90,7 +90,8 @@ public:
     // Chained assumption specifics 
     const std::string body = fmt::format(StsChainedFormatString, role_arn, now);
     message->body().add(body);
-    // this call resets the sha as nothing should be added prior to this.
+    // this call resets the sha so that our authenticator is in a fresh state
+    // to be reused.
     aws_authenticator_.resetSHA(); 
     aws_authenticator_.init(&creds->accessKeyId().value(), 
         &creds->secretAccessKey().value(), &creds->sessionToken().value());

--- a/test/extensions/filters/http/aws_lambda/aws_authenticator_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_authenticator_test.cc
@@ -61,7 +61,7 @@ public:
 };
 const std::string AwsAuthenticatorTest::SERVICE = "service";
 
-TEST_F(AwsAuthenticatorTest, BodyHash) {
+TEST_F(AwsAuthenticatorTest, RepeatedlyBodyHash) {
   DangerousDeprecatedTestTime time;
   AwsAuthenticator aws(time.timeSystem());
 
@@ -73,7 +73,15 @@ TEST_F(AwsAuthenticatorTest, BodyHash) {
   std::string hexsha = getBodyHexSha(aws);
   EXPECT_EQ("6cc43f858fbb763301637b5af970e2a46b46f461f27e5a0f41e009c59b827b25",
             hexsha);
+
+  // can reuse the authenticator
+  aws.init(&accesskey, &secretkey, nullptr);
+  updatePayloadHash(aws, "\"abc\"");
+  hexsha = getBodyHexSha(aws);
+  EXPECT_EQ("6cc43f858fbb763301637b5af970e2a46b46f461f27e5a0f41e009c59b827b25",
+            hexsha);
 }
+
 
 TEST_F(AwsAuthenticatorTest, UrlQuery) {
   DangerousDeprecatedTestTime time;

--- a/test/extensions/filters/http/aws_lambda/aws_authenticator_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_authenticator_test.cc
@@ -73,13 +73,6 @@ TEST_F(AwsAuthenticatorTest, RepeatedlyBodyHash) {
   std::string hexsha = getBodyHexSha(aws);
   EXPECT_EQ("6cc43f858fbb763301637b5af970e2a46b46f461f27e5a0f41e009c59b827b25",
             hexsha);
-
-  // can reuse the authenticator after reset
-  aws.resetSHA();
-  updatePayloadHash(aws, "\"abc\"");
-  hexsha = getBodyHexSha(aws);
-  EXPECT_EQ("6cc43f858fbb763301637b5af970e2a46b46f461f27e5a0f41e009c59b827b25",
-            hexsha);
 }
 
 

--- a/test/extensions/filters/http/aws_lambda/aws_authenticator_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_authenticator_test.cc
@@ -74,8 +74,9 @@ TEST_F(AwsAuthenticatorTest, RepeatedlyBodyHash) {
   EXPECT_EQ("6cc43f858fbb763301637b5af970e2a46b46f461f27e5a0f41e009c59b827b25",
             hexsha);
 
-  // can reuse the authenticator
-  aws.init(&accesskey, &secretkey, nullptr);
+
+  // can reuse the authenticator after reset
+  aws.resetSHA();
   updatePayloadHash(aws, "\"abc\"");
   hexsha = getBodyHexSha(aws);
   EXPECT_EQ("6cc43f858fbb763301637b5af970e2a46b46f461f27e5a0f41e009c59b827b25",

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -367,14 +367,14 @@ TEST_F(AWSLambdaFilterTest, SignsDataSetByPreviousFilters) {
 
 
   StsConnectionPool::Context::Callbacks *callbackReference;
-  auto fakeContext = new StsContextStub();
+  StsContextStub fakeContext;
   EXPECT_CALL(*filter_config_, getCreds).WillRepeatedly(
      [&](StsConnectionPool::Context::Callbacks *callbacks) ->
                                          StsConnectionPool::Context*{
         callbackReference = callbacks;
         // context is used for evaluating if we are in async
         // only other use is cancel so just use stub.
-        return fakeContext;
+        return &fakeContext;
      }
   );
 

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -367,13 +367,14 @@ TEST_F(AWSLambdaFilterTest, SignsDataSetByPreviousFilters) {
 
 
   StsConnectionPool::Context::Callbacks *callbackReference;
+  auto fakeContext = new StsContextStub();
   EXPECT_CALL(*filter_config_, getCreds).WillRepeatedly(
      [&](StsConnectionPool::Context::Callbacks *callbacks) ->
                                          StsConnectionPool::Context*{
         callbackReference = callbacks;
         // context is used for evaluating if we are in async
         // only other use is cancel so just use stub.
-        return new StsContextStub();
+        return fakeContext;
      }
   );
 

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -358,14 +358,14 @@ TEST_F(AWSLambdaFilterTest, SignsDataSetByPreviousFilters) {
   EXPECT_CALL(*filter_config_, getCreds).WillRepeatedly(
      [&](StsConnectionPool::Context::Callbacks *callbacks){
         callbackReference = callbacks;
-     })
+     }
   );
 
   filter_->decodeHeaders(headers, false);
   callbackReference->onSuccess(filter_config_->credentials_);
   filter_->decodeData(data, false);
   filter_->decodeTrailers(trailers);
-  auto auth = filter_->aws_authenticator();
+  auto auth = filter_->awsAuthenticator();
   auto hex_sha1 = auth.getBodyHexSha();
 
   filter_ = std::make_unique<AWSLambdaFilter>(
@@ -391,7 +391,7 @@ TEST_F(AWSLambdaFilterTest, SignsDataSetByPreviousFilters) {
   
   callbackReference->onSuccess(filter_config_->credentials_);
   filter_->decodeTrailers(trailers_2);
-  auto auth2 = filter_->aws_authenticator();
+  auto auth2 = filter_->awsAuthenticator();
   auto hex_sha2 = auth2.getBodyHexSha();
 
   EXPECT_EQ(hex_sha1, hex_sha2);

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_filter_test.cc
@@ -7,6 +7,7 @@
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/utility.h"
 
+
 #include "fmt/format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -31,11 +32,7 @@ public:
       SharedAWSLambdaProtocolExtensionConfig,
       StsConnectionPool::Context::Callbacks *callbacks) const override {
     called_ = true;
-    if (credentials_ == nullptr) {
-      callbacks->onFailure(CredentialsFailureStatus::Network);
-    } else {
-      callbacks->onSuccess(credentials_);
-    }
+    getCreds(callbacks);
     return nullptr;
   }
 
@@ -45,6 +42,11 @@ public:
   bool propagateOriginalRouting() const override{
     return propagate_original_routing_;
   }
+
+  MOCK_METHOD(void, getCreds, (StsConnectionPool::Context::Callbacks *callbacks), (const));
+
+  
+
   bool propagate_original_routing_;
 };
 
@@ -56,7 +58,8 @@ protected:
   void SetUp() override { setupRoute(); }
 
   void setupRoute(bool sessionToken = false, bool noCredentials = false,
-                bool persistOriginalHeaders = false, bool unwrapAsAlb = false) {
+                bool persistOriginalHeaders = false, bool unwrapAsAlb = false,
+                bool unmanagedCredentials = false) {
     factory_context_.cluster_manager_.initializeClusters({"fake_cluster"}, {});
     factory_context_.cluster_manager_.initializeThreadLocalClusters({"fake_cluster"});
 
@@ -71,7 +74,8 @@ protected:
         protoextconfig;
     protoextconfig.set_host("lambda.us-east-1.amazonaws.com");
     protoextconfig.set_region("us-east-1");
-    filter_config_ = std::make_shared<AWSLambdaConfigTestImpl>();
+    filter_config_ = std::make_shared<testing::NiceMock<
+                                      AWSLambdaConfigTestImpl>>();
 
     if (!noCredentials) {
       if (sessionToken) {
@@ -84,6 +88,17 @@ protected:
                 "access key", "secret key");
       }
     }
+    if (!unmanagedCredentials){
+      ON_CALL(*filter_config_, getCreds).WillByDefault(
+                        [this](StsConnectionPool::Context::Callbacks *callbacks){
+          if (filter_config_->credentials_ == nullptr) {
+              callbacks->onFailure(CredentialsFailureStatus::Network);
+          } else {
+            callbacks->onSuccess(filter_config_->credentials_);
+          }
+        }
+      );
+    }
     
     filter_config_->propagate_original_routing_=persistOriginalHeaders;
 
@@ -94,10 +109,13 @@ protected:
             Return(std::make_shared<AWSLambdaProtocolExtensionConfig>(
                 protoextconfig)));
 
+
     filter_ = std::make_unique<AWSLambdaFilter>(
         factory_context_.cluster_manager_, factory_context_.api_,
         filter_config_);
     filter_->setDecoderFilterCallbacks(filter_callbacks_);
+
+    
   }
 
   void setup_func() {
@@ -129,7 +147,7 @@ protected:
   std::unique_ptr<AWSLambdaFilter> filter_;
   envoy::config::filter::http::aws_lambda::v2::AWSLambdaPerRoute routeconfig_;
   std::unique_ptr<AWSLambdaRouteConfig> filter_route_config_;
-  std::shared_ptr<AWSLambdaConfigTestImpl> filter_config_;
+  std::shared_ptr<NiceMock<AWSLambdaConfigTestImpl>> filter_config_;
 };
 
 // see:
@@ -319,6 +337,64 @@ TEST_F(AWSLambdaFilterTest, SignOnTrailedEndStream) {
             filter_->decodeTrailers(trailers));
 
   EXPECT_TRUE(headers.has("Authorization"));
+}
+
+TEST_F(AWSLambdaFilterTest, SignsDataSetByPreviousFilters) {
+  // there are cases where even if our filter is waiting on decode headers
+  // decode data can still happen. We need to verify that bodysha is still
+  // handled appropriately.
+
+  // we will manage credentials callbacks ourselves for this test
+  setupRoute(false, false, false, false, true);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":authority", "www.solo.io"},
+                                         {":path", "/getsomething"}};
+  Buffer::OwnedImpl data("data");
+  Http::TestRequestTrailerMapImpl trailers;
+
+
+  StsConnectionPool::Context::Callbacks *callbackReference;
+  EXPECT_CALL(*filter_config_, getCreds).WillRepeatedly(
+     [&](StsConnectionPool::Context::Callbacks *callbacks){
+        callbackReference = callbacks;
+     })
+  );
+
+  filter_->decodeHeaders(headers, false);
+  callbackReference->onSuccess(filter_config_->credentials_);
+  filter_->decodeData(data, false);
+  filter_->decodeTrailers(trailers);
+  auto auth = filter_->aws_authenticator();
+  auto hex_sha1 = auth.getBodyHexSha();
+
+  filter_ = std::make_unique<AWSLambdaFilter>(
+      factory_context_.cluster_manager_, factory_context_.api_,
+      filter_config_);
+  filter_->setDecoderFilterCallbacks(filter_callbacks_);
+
+
+  // Pointers are a thing so lets just restate the above values
+  Http::TestRequestHeaderMapImpl headers_2{{":method", "GET"},
+                                         {":authority", "www.solo.io"},
+                                         {":path", "/getsomething"}};
+  Buffer::OwnedImpl data_2("data");
+  Http::TestRequestTrailerMapImpl trailers_2;
+
+  Buffer::OwnedImpl diff_data("different");
+
+
+
+  // intentionally misorder our on success to simulate a long sts call.
+  filter_->decodeHeaders(headers_2, false);
+  filter_->decodeData(data_2, false);
+  
+  callbackReference->onSuccess(filter_config_->credentials_);
+  filter_->decodeTrailers(trailers_2);
+  auto auth2 = filter_->aws_authenticator();
+  auto hex_sha2 = auth2.getBodyHexSha();
+
+  EXPECT_EQ(hex_sha1, hex_sha2);
 }
 
 TEST_F(AWSLambdaFilterTest, InvalidFunction) {


### PR DESCRIPTION
Update to caching for lambda auth and auth reuse given misordered data when waiting in headers