### PR TITLE
Create Base64 and Substring Transformation Functions

### DIFF
--- a/changelog/v1.23.1-patch2/base64_transformation_functions.yaml
+++ b/changelog/v1.23.1-patch2/base64_transformation_functions.yaml
@@ -1,7 +1,7 @@
 changelog:
 - type: NEW_FEATURE
   description: >
-    Creates base64Encode and base64Decode Inja functions, which can be used in
+    Creates base64_encode and base64_decode Inja functions, which can be used in
     transformation templates.
   issueLink: https://github.com/solo-io/gloo/issues/3597
   resolvesIssue: false

--- a/changelog/v1.23.1-patch2/base64_transformation_functions.yaml
+++ b/changelog/v1.23.1-patch2/base64_transformation_functions.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NEW_FEATURE
+  description: >
+    Creates base64Encode and base64Decode Inja functions, which can be used in
+    transformation templates.
+  issueLink: https://github.com/solo-io/gloo/issues/3597
+  resolvesIssue: false

--- a/changelog/v1.23.1-patch2/base64_transformation_functions.yaml
+++ b/changelog/v1.23.1-patch2/base64_transformation_functions.yaml
@@ -1,7 +1,7 @@
 changelog:
 - type: NEW_FEATURE
   description: >
-    Creates base64_encode and base64_decode Inja functions, which can be used in
+    Creates base64_encode, base64_decode, and substring Inja functions, which can be used in
     transformation templates.
   issueLink: https://github.com/solo-io/gloo/issues/3597
   resolvesIssue: false

--- a/source/extensions/filters/http/transformation/BUILD
+++ b/source/extensions/filters/http/transformation/BUILD
@@ -86,6 +86,7 @@ envoy_cc_library(
         "//source/extensions/filters/http:solo_well_known_names",
         "@envoy//envoy/buffer:buffer_interface",
         "@envoy//envoy/http:header_map_interface",
+        "@envoy//source/common/common:base64_lib",
         "@envoy//source/common/common:macros",
         "@envoy//source/common/common:regex_lib",
         "@envoy//source/common/common:utility_lib",

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -132,6 +132,9 @@ TransformerInstance::TransformerInstance(
   env_.add_callback("base64Decode", 1, [this](Arguments &args) {
     return base64_decode_callback(args); 
   });
+  env_.add_callback("substring", 3, [this](Arguments &args) {
+    return substring_callback(args); 
+  });
 }
 
 json TransformerInstance::header_callback(const inja::Arguments &args) const {
@@ -258,6 +261,30 @@ json TransformerInstance::base64_encode_callback(const inja::Arguments &args) co
 json TransformerInstance::base64_decode_callback(const inja::Arguments &args) const {
   const std::string &input = args.at(0)->get_ref<const std::string &>();
   return Base64::decode(input);
+}
+
+json TransformerInstance::substring_callback(const inja::Arguments &args) const {
+  const std::string &input = args.at(0)->get_ref<const std::string &>();
+  const int64_t start = args.at(1)->get_ref<const int64_t &>();
+  const int64_t substring_len = args.at(2)->get_ref<const int64_t &>();
+
+  // store input length 
+  const int64_t input_len = input.length();
+
+  // if start is negative, substring_len is non-positive, or 
+  // start is greater than the length of the string, return empty string
+  if (start < 0 || substring_len <= 0 || start >= input_len) {
+    return "";
+  }
+
+  // if start + len is greater than the length of the string, return the substring
+  // from start to the end of the string
+  if (start + substring_len > input_len) {
+    return input.substr(start);
+  }
+
+  // otherwise, return the substring from start to start + len
+  return input.substr(start, substring_len);
 }
 
 std::string TransformerInstance::render(const inja::Template &input) {

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -274,8 +274,10 @@ json TransformerInstance::base64_decode_callback(const inja::Arguments &args) co
 // and extending for length characters. If length is not provided, the
 // substring will extend to the end of the string.
 json TransformerInstance::substring_callback(const inja::Arguments &args) const {
+  // get first argument, which is the string to be modified
   const std::string &input = args.at(0)->get_ref<const std::string &>();
-  // try to get first argument (start position) as an int64_t
+  
+  // try to get second argument (start position) as an int64_t
   int start = 0;
   try {
     start = args.at(1)->get_ref<const int64_t &>();
@@ -284,7 +286,7 @@ json TransformerInstance::substring_callback(const inja::Arguments &args) const 
     return "";
   }
 
-  // try to get optional substring_len argument
+  // try to get optional third argument (length) as an int64_t
   int64_t substring_len = -1;
   if (args.size() == 3) {
     try {

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -132,6 +132,12 @@ TransformerInstance::TransformerInstance(
   env_.add_callback("base64_decode", 1, [this](Arguments &args) {
     return base64_decode_callback(args); 
   });
+  // Substring can be called with either two or three arguments --
+  // the first argument is the string to be modified, the second is the start position
+  // of the substring, and the optional third argument is the length of the substring.
+  env_.add_callback("substring", 2, [this](Arguments &args) {
+    return substring_callback(args); 
+  });
   env_.add_callback("substring", 3, [this](Arguments &args) {
     return substring_callback(args); 
   });
@@ -266,7 +272,11 @@ json TransformerInstance::base64_decode_callback(const inja::Arguments &args) co
 json TransformerInstance::substring_callback(const inja::Arguments &args) const {
   const std::string &input = args.at(0)->get_ref<const std::string &>();
   const int64_t start = args.at(1)->get_ref<const int64_t &>();
-  const int64_t substring_len = args.at(2)->get_ref<const int64_t &>();
+  // get optional substring_len argument
+  int64_t substring_len = -1;
+  if (args.size() == 3) {
+    substring_len = args.at(2)->get_ref<const int64_t &>();
+  }
   const int64_t input_len = input.length();
 
   // if start is negative, or start is greater than the length of the string, return empty string

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -267,19 +267,16 @@ json TransformerInstance::substring_callback(const inja::Arguments &args) const 
   const std::string &input = args.at(0)->get_ref<const std::string &>();
   const int64_t start = args.at(1)->get_ref<const int64_t &>();
   const int64_t substring_len = args.at(2)->get_ref<const int64_t &>();
-
-  // store input length 
   const int64_t input_len = input.length();
 
-  // if start is negative, substring_len is non-positive, or 
-  // start is greater than the length of the string, return empty string
-  if (start < 0 || substring_len <= 0 || start >= input_len) {
+  // if start is negative, or start is greater than the length of the string, return empty string
+  if (start < 0 ||  start >= input_len) {
     return "";
   }
 
-  // if start + len is greater than the length of the string, return the substring
-  // from start to the end of the string
-  if (start + substring_len > input_len) {
+  // if supplied substring_len is <= 0 or start + substring_len is greater than the length of the string, 
+  // return the substring from start to the end of the string
+  if (substring_len <= 0 || start + substring_len > input_len) {
     return input.substr(start);
   }
 

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -126,10 +126,10 @@ TransformerInstance::TransformerInstance(
   env_.add_callback("clusterMetadata", 1, [this](Arguments &args) {
     return cluster_metadata_callback(args);
   });
-  env_.add_callback("base64Encode", 1, [this](Arguments &args) {
+  env_.add_callback("base64_encode", 1, [this](Arguments &args) {
     return base64_encode_callback(args); 
   });
-  env_.add_callback("base64Decode", 1, [this](Arguments &args) {
+  env_.add_callback("base64_decode", 1, [this](Arguments &args) {
     return base64_decode_callback(args); 
   });
   env_.add_callback("substring", 3, [this](Arguments &args) {

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -126,6 +126,14 @@ TransformerInstance::TransformerInstance(
   env_.add_callback("clusterMetadata", 1, [this](Arguments &args) {
     return cluster_metadata_callback(args);
   });
+  // NTS: does the order these callbacks are added affect anything?
+  // I assume that they're transposable and that the order doesn't matter.
+  env_.add_callback("base64Encode", 1, [this](Arguments &args) {
+    return base64_encode_callback(args); 
+  });
+  env_.add_callback("base64Decode", 1, [this](Arguments &args) {
+    return base64_decode_callback(args); 
+  });
 }
 
 json TransformerInstance::header_callback(const inja::Arguments &args) const {
@@ -242,6 +250,16 @@ json TransformerInstance::cluster_metadata_callback(
   }
   }
   return "";
+}
+
+json TransformerInstance::base64_encode_callback(const inja::Arguments &args) const {
+  const std::string &input = args.at(0)->get_ref<const std::string &>();
+  return Base64::encode(input.c_str(), input.length());
+}
+
+json TransformerInstance::base64_decode_callback(const inja::Arguments &args) const {
+  const std::string &input = args.at(0)->get_ref<const std::string &>();
+  return Base64::decode(input);
 }
 
 std::string TransformerInstance::render(const inja::Template &input) {

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -126,8 +126,6 @@ TransformerInstance::TransformerInstance(
   env_.add_callback("clusterMetadata", 1, [this](Arguments &args) {
     return cluster_metadata_callback(args);
   });
-  // NTS: does the order these callbacks are added affect anything?
-  // I assume that they're transposable and that the order doesn't matter.
   env_.add_callback("base64Encode", 1, [this](Arguments &args) {
     return base64_encode_callback(args); 
   });

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -5,6 +5,8 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/http/header_map.h"
 
+#include "source/common/common/base64.h"
+
 #include "source/extensions/filters/http/transformation/transformer.h"
 
 // clang-format off
@@ -42,6 +44,8 @@ private:
   nlohmann::json dynamic_metadata(const inja::Arguments &args) const;
   nlohmann::json env(const inja::Arguments &args) const;
   nlohmann::json cluster_metadata_callback(const inja::Arguments &args) const;
+  nlohmann::json base64_encode_callback(const inja::Arguments &args) const;
+  nlohmann::json base64_decode_callback(const inja::Arguments &args) const;
 
   inja::Environment env_;
   const Http::RequestOrResponseHeaderMap &header_map_;

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -46,6 +46,7 @@ private:
   nlohmann::json cluster_metadata_callback(const inja::Arguments &args) const;
   nlohmann::json base64_encode_callback(const inja::Arguments &args) const;
   nlohmann::json base64_decode_callback(const inja::Arguments &args) const;
+  nlohmann::json substring_callback(const inja::Arguments &args) const;
 
   inja::Environment env_;
   const Http::RequestOrResponseHeaderMap &header_map_;

--- a/test/extensions/filters/http/transformation/BUILD
+++ b/test/extensions/filters/http/transformation/BUILD
@@ -19,6 +19,7 @@ envoy_gloo_cc_test(
     repository = "@envoy",
     deps = [
         "//source/extensions/filters/http/transformation:inja_transformer_lib",
+        "@envoy//source/common/common:base64_lib",
         "@envoy//test/test_common:environment_lib",
         "@envoy//test/mocks/http:http_mocks",
         "@envoy//test/mocks/server:server_mocks",

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -805,6 +805,29 @@ TEST(InjaTransformer, SubstringOutOfBounds) {
   EXPECT_EQ(body.toString(), "123");
 }
 
+TEST(InjaTransformer, SubstringNonIntegerArguments) {
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
+  TransformationTemplate transformation;
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+
+  auto test_string = "123";
+
+  // case: start index is not an integer
+  transformation.mutable_body()->set_text("{{substring(body(), \"a\", 1)}}");
+  InjaTransformer transformer(transformation);
+  Buffer::OwnedImpl body(test_string);
+  transformer.transform(headers, &headers, body, callbacks);
+  EXPECT_EQ(body.toString(), "");
+
+  // case: substring length is not an integer
+  transformation.mutable_body()->set_text("{{substring(body(), 0, \"a\")}}");
+  InjaTransformer transformer2(transformation);
+  body = Buffer::OwnedImpl(test_string);
+  transformer2.transform(headers, &headers, body, callbacks);
+  EXPECT_EQ(body.toString(), "");
+}
+
 TEST(InjaTransformer, ParseBodyListUsingContext) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
   TransformationTemplate transformation;

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -774,19 +774,19 @@ TEST(InjaTransformer, SubstringOutOfBounds) {
   transformer2.transform(headers, &headers, body, callbacks);
   EXPECT_EQ(body.toString(), "");
 
-  // case: transformation length is greater than string length
+  // case: substring length is greater than string length
   transformation.mutable_body()->set_text("{{substring(body(), 0, 10)}}");
   InjaTransformer transformer3(transformation);
   body = Buffer::OwnedImpl(test_string);
   transformer3.transform(headers, &headers, body, callbacks);
   EXPECT_EQ(body.toString(), "123");
 
-  // case: transformation length is negative
+  // case: substring length is negative
   transformation.mutable_body()->set_text("{{substring(body(), 0, -1)}}");
   InjaTransformer transformer4(transformation);
   body = Buffer::OwnedImpl(test_string);
   transformer4.transform(headers, &headers, body, callbacks);
-  EXPECT_EQ(body.toString(), "");
+  EXPECT_EQ(body.toString(), "123");
 }
 
 TEST(InjaTransformer, ParseBodyListUsingContext) {

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -687,7 +687,7 @@ TEST(InjaTransformer, Base64EncodeTestString) {
   TransformationTemplate transformation;
 
   auto test_string = "test";
-  auto formatted_string = fmt::format("{{{{base64Encode(\"{}\")}}}}", test_string);
+  auto formatted_string = fmt::format("{{{{base64_encode(\"{}\")}}}}", test_string);
 
   transformation.mutable_body()->set_text(formatted_string);
 
@@ -707,7 +707,7 @@ TEST(InjaTransformer, Base64DecodeTestString) {
   std::string test_string = "test";
   auto encoded_string = Base64::encode(test_string.c_str(), test_string.length());
 
-  auto formatted_string = fmt::format("{{{{base64Decode(\"{}\")}}}}", encoded_string);
+  auto formatted_string = fmt::format("{{{{base64_decode(\"{}\")}}}}", encoded_string);
 
   transformation.mutable_body()->set_text(formatted_string);
 
@@ -724,7 +724,7 @@ TEST(InjaTransformer, Base64Composed) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
   TransformationTemplate transformation;
 
-  transformation.mutable_body()->set_text("{{base64Decode(base64Encode(body()))}}");
+  transformation.mutable_body()->set_text("{{base64_decode(base64_encode(body()))}}");
 
   InjaTransformer transformer(transformation);
 

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -736,6 +736,21 @@ TEST(InjaTransformer, Base64Composed) {
   EXPECT_EQ(body.toString(), test_string);
 }
 
+TEST(InjaTransformer, DecodeInvalidBase64) {
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
+  TransformationTemplate transformation;
+
+  transformation.mutable_body()->set_text("{{base64_decode(\"INVALID BASE64\")}}");
+
+  InjaTransformer transformer(transformation);
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+
+  Buffer::OwnedImpl body("");
+  transformer.transform(headers, &headers, body, callbacks);
+  EXPECT_EQ(body.toString(), "");
+}
+
 TEST(InjaTransformer, Substring) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
   TransformationTemplate transformation;

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -752,6 +752,22 @@ TEST(InjaTransformer, Substring) {
   EXPECT_EQ(body.toString(), "23");
 }
 
+TEST(InjaTransformer, SubstringTwoArguments) {
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
+  TransformationTemplate transformation;
+
+  transformation.mutable_body()->set_text("{{substring(body(), 1)}}");
+
+  InjaTransformer transformer(transformation);
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+
+  auto test_string = "123";
+  Buffer::OwnedImpl body(test_string);
+  transformer.transform(headers, &headers, body, callbacks);
+  EXPECT_EQ(body.toString(), "23");
+}
+
 TEST(InjaTransformer, SubstringOutOfBounds) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
   TransformationTemplate transformation;


### PR DESCRIPTION
# Description
 - Creates `base64_encode` and `base64_decode` Inja functions
 - Creates `substring` Inja function

# Context

 - This functionality was requested in https://github.com/solo-io/gloo/issues/3597
   -  although the issue title just calls out the need for base64 decoding, I have added base64 encoding and substring Inja functions
   - In particular, the use case detailed in the issue comments requires a substring of the decoded base64 string to be extracted, hence the inclusion of the substring function
 - I will be leaving this PR as a draft until I have validated it via Gloo Edge e2e tests
   - Update: These functions are validated here: https://github.com/solo-io/gloo/pull/7255/files
   - These tests pass for me when I run them locally, although it seems like Gloo Edge CI might be having issues pulling the non-released envoy-gloo image