### PR TITLE
Fix: wrapAsApiGateway crashes Envoy on headers-only request

### DIFF
--- a/changelog/v1.23.1-patch3/header_request_wrap_as_api_gateway_fix.yaml
+++ b/changelog/v1.23.1-patch3/header_request_wrap_as_api_gateway_fix.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/7307
+  resolvesIssue: false
+  description: >
+    Resolves a bug which caused envoy to crash when a headers-only request was sent
+    to an AWS Lambda upstream with wrapAsApiGateway enabled.

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -418,7 +418,7 @@ void AWSLambdaFilter::handleDefaultBody() {
 void AWSLambdaFilter::transformRequest() {
   auto request_transformer_config = functionOnRoute()->requestTransformerConfig();
   // if we're processing a headers-only request, the decoding buffer does not exist,
-  // so we need to transform an empty buffer and then add it to the decoding buffer
+  // so we need to transform an empty buffer and then create the decoding buffer from it
   if (!has_body_) {
     Buffer::OwnedImpl body_buffer("");
     request_transformer_config->transform(*request_headers_, request_headers_, body_buffer, *decoder_callbacks_);

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -420,15 +420,17 @@ void AWSLambdaFilter::transformRequest() {
   // if we're processing a headers-only request, the decoding buffer does not exist,
   // so we need to transform an empty buffer and then create the decoding buffer from it
   if (!has_body_) {
+    ENVOY_LOG(debug, "Performing request transformation on empty buffer");
     Buffer::OwnedImpl body_buffer("");
     request_transformer_config->transform(*request_headers_, request_headers_, body_buffer, *decoder_callbacks_);
-    decoder_callbacks_->addDecodedData(body_buffer, false); // set the decoding buffer to the transformed buffer
     request_headers_->setContentLength(body_buffer.length());
     aws_authenticator_.updatePayloadHash(body_buffer);
+    decoder_callbacks_->addDecodedData(body_buffer, false); // set the decoding buffer to the transformed buffer
     return;
   }
 
   // if we're processing a request with a body, we modify the decoding buffer directly
+  ENVOY_LOG(debug, "Performing request transformation on non-empty buffer");
   decoder_callbacks_->modifyDecodingBuffer([this, &request_transformer_config](Buffer::Instance &buffer) {
     request_transformer_config->transform(*request_headers_, request_headers_, buffer, *decoder_callbacks_);
     request_headers_->setContentLength(buffer.length());

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_transformer_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_transformer_test.cc
@@ -254,7 +254,7 @@ TEST_F(AWSLambdaTransformerTest, TestConfigureRequestTransformerSignatureNoBody)
 
 
   EXPECT_EQ(transformedxAmzDateHeader[0]->value().getStringView(), "20010909T014640Z");
-  EXPECT_EQ(transformedAuthorizationHeader[0]->value().getStringView(), "AWS4-HMAC-SHA256 Credential=access key/20010909/us-east-1/lambda/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-invocation-type;x-amz-log-type, Signature=6ac2a229351a686ff5a93deb46896f2128a6800a885ef5324c0c0685aa21d786");
+  EXPECT_EQ(transformedAuthorizationHeader[0]->value().getStringView(), "AWS4-HMAC-SHA256 Credential=access key/20010909/us-east-1/lambda/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-invocation-type;x-amz-log-type, Signature=561409e1250c56044b11a3d6eaed9f3d3d9467f3214dfec4786a65381bdab23e");
 
   // now, setup to use no transformer
   setupRoute(false, false);
@@ -293,6 +293,24 @@ TEST_F(AWSLambdaTransformerTest, TestConfigureResponseTransformer){
 
   EXPECT_EQ(Http::FilterDataStatus::Continue, edResult);
   EXPECT_STREQ("test body from fake transformer", buf.toString().c_str());
+}
+
+TEST_F(AWSLambdaTransformerTest, TestNoBodyRequestTransformation){
+  setupRoute(false, true);
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":authority", "www.solo.io"},
+                                         {":path", "/getsomething"}};
+  
+  time_system_.setSystemTime(std::chrono::milliseconds(1000000000000));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter_->decodeHeaders(headers, true));
+
+
+  auto transformedAuthorizationHeader = headers.get(Http::LowerCaseString("authorization"));
+  auto transformedxAmzDateHeader = headers.get(Http::LowerCaseString("x-amz-date"));
+
+  EXPECT_EQ(transformedxAmzDateHeader[0]->value().getStringView(), "20010909T014640Z");
+  EXPECT_EQ(transformedAuthorizationHeader[0]->value().getStringView(), "AWS4-HMAC-SHA256 Credential=access key/20010909/us-east-1/lambda/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-invocation-type;x-amz-log-type, Signature=561409e1250c56044b11a3d6eaed9f3d3d9467f3214dfec4786a65381bdab23e");
 }
 
 } // namespace AwsLambda


### PR DESCRIPTION
# Description

- Resolves a bug which caused envoy to crash when a headers-only request was sent to an AWS Lambda upstream with `wrapAsApiGateway` enabled.
- This occurred because we previously called `decoder_callbacks_->modifyDecodingBuffer` whenever `wrapAsApiGateway` was enabled
  - Because a decoding buffer does not exist on a headers-only request, attempting to modify a nonexistent decoding buffer caused Envoy to crash
- Now, we transform an empty buffer and then create a decoding buffer from the transformed result using `decoder_callbacks_->addDecodedData` in the case of a headers only request

# Context

- The original issue reporting this bug can be found here: https://github.com/solo-io/gloo/issues/7307
- I will put up and link a solo-projects draft PR with e2e tests that validate this fix end-to-end
  - Update: that PR can be found here https://github.com/solo-io/solo-projects/pull/4177
- That PR will eventually include an envoy-gloo-ee version bump which pulls in the changes contained in this PR