### PR TITLE
AWS Lambda: Fix issues with request metadata when processing request transformation

### DIFF
--- a/changelog/v1.24.0-patch2/request-metadata.yaml
+++ b/changelog/v1.24.0-patch2/request-metadata.yaml
@@ -3,7 +3,7 @@ changelog:
   issueLink: https://github.com/solo-io/solo-projects/issues/4353
   resolvesIssue: false
   description: >
-    Resolves a error when processing request transformations in the AWS lambda
+    Resolves an error when processing request transformations in the AWS lambda
     filter. Prior to this change, the AWS lambda filter would modify the :path
     and :method pseudo-headers before the request transformation was
     processed, resulting in the upstream receiving invalid values of these

--- a/changelog/v1.24.0-patch2/request-metadata.yaml
+++ b/changelog/v1.24.0-patch2/request-metadata.yaml
@@ -1,0 +1,10 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/4353
+  resolvesIssue: false
+  description: >
+    Resolves a error when processing request transformations in the AWS lambda
+    filter. Prior to this change, the AWS lambda filter would modify the :path
+    and :method pseudo-headers before the request transformation was
+    processed, resulting in the upstream receiving invalid values of these
+    headers.

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -314,30 +314,6 @@ void AWSLambdaFilter::onSuccess(
   }
 }
 
-// update headers before sending to AWS
-// must be called after any request transformations are processed
-void AWSLambdaFilter::updateHeaders() {
-  if (filter_config_->propagateOriginalRouting()){
-    request_headers_->setEnvoyOriginalPath(request_headers_->getPathValue());
-    request_headers_->addReferenceKey(Http::Headers::get().EnvoyOriginalMethod,
-                                      request_headers_->getMethodValue());
-  }
-
-  request_headers_->setReferenceMethod(Http::Headers::get().MethodValues.Post);
-
-  request_headers_->setReferencePath(function_on_route_->path());
-
-  const std::string &invocation_type =
-      function_on_route_->async()
-          ? AWSLambdaHeaderNames::get().InvocationTypeEvent
-          : AWSLambdaHeaderNames::get().InvocationTypeRequestResponse;
-  request_headers_->addReference(AWSLambdaHeaderNames::get().InvocationType,
-                                 invocation_type);
-  request_headers_->addReference(AWSLambdaHeaderNames::get().LogType,
-                                 AWSLambdaHeaderNames::get().LogNone);
-  request_headers_->setReferenceHost(protocol_options_->host());
-}
-
 // TODO: Use the failure status in the local reply
 void AWSLambdaFilter::onFailure(CredentialsFailureStatus) {
   // cancel mustn't be called
@@ -418,6 +394,30 @@ void AWSLambdaFilter::handleDefaultBody() {
     aws_authenticator_.updatePayloadHash(data);
     decoder_callbacks_->addDecodedData(data, false);
   }
+}
+
+// update headers before sending to AWS
+// must be called after any request transformations are processed
+void AWSLambdaFilter::updateHeaders() {
+  if (filter_config_->propagateOriginalRouting()){
+    request_headers_->setEnvoyOriginalPath(request_headers_->getPathValue());
+    request_headers_->addReferenceKey(Http::Headers::get().EnvoyOriginalMethod,
+                                      request_headers_->getMethodValue());
+  }
+
+  request_headers_->setReferenceMethod(Http::Headers::get().MethodValues.Post);
+
+  request_headers_->setReferencePath(function_on_route_->path());
+
+  const std::string &invocation_type =
+      function_on_route_->async()
+          ? AWSLambdaHeaderNames::get().InvocationTypeEvent
+          : AWSLambdaHeaderNames::get().InvocationTypeRequestResponse;
+  request_headers_->addReference(AWSLambdaHeaderNames::get().InvocationType,
+                                 invocation_type);
+  request_headers_->addReference(AWSLambdaHeaderNames::get().LogType,
+                                 AWSLambdaHeaderNames::get().LogNone);
+  request_headers_->setReferenceHost(protocol_options_->host());
 }
 
 void AWSLambdaFilter::transformRequest() {

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -303,6 +303,20 @@ void AWSLambdaFilter::onSuccess(
   }
   aws_authenticator_.init(access_key, secret_key, session_token);
 
+  if (stopped_) {
+    if (end_stream_) {
+      // edge case where header only request was stopped, but now needs to be
+      // lambdafied.
+      lambdafy();
+    }
+    stopped_ = false;
+    decoder_callbacks_->continueDecoding();
+  }
+}
+
+// update headers before sending to AWS
+// must be called after any request transformations are processed
+void AWSLambdaFilter::updateHeaders() {
   if (filter_config_->propagateOriginalRouting()){
     request_headers_->setEnvoyOriginalPath(request_headers_->getPathValue());
     request_headers_->addReferenceKey(Http::Headers::get().EnvoyOriginalMethod,
@@ -313,15 +327,15 @@ void AWSLambdaFilter::onSuccess(
 
   request_headers_->setReferencePath(function_on_route_->path());
 
-  if (stopped_) {
-    if (end_stream_) {
-      // edge case where header only request was stopped, but now needs to be
-      // lambdafied.
-      lambdafy();
-    }
-    stopped_ = false;
-    decoder_callbacks_->continueDecoding();
-  }
+  const std::string &invocation_type =
+      function_on_route_->async()
+          ? AWSLambdaHeaderNames::get().InvocationTypeEvent
+          : AWSLambdaHeaderNames::get().InvocationTypeRequestResponse;
+  request_headers_->addReference(AWSLambdaHeaderNames::get().InvocationType,
+                                 invocation_type);
+  request_headers_->addReference(AWSLambdaHeaderNames::get().LogType,
+                                 AWSLambdaHeaderNames::get().LogNone);
+  request_headers_->setReferenceHost(protocol_options_->host());
 }
 
 // TODO: Use the failure status in the local reply
@@ -389,16 +403,7 @@ void AWSLambdaFilter::lambdafy() {
   if (isRequestTransformationNeeded()) {
       transformRequest();
   }
-
-  const std::string &invocation_type =
-      function_on_route_->async()
-          ? AWSLambdaHeaderNames::get().InvocationTypeEvent
-          : AWSLambdaHeaderNames::get().InvocationTypeRequestResponse;
-  request_headers_->addReference(AWSLambdaHeaderNames::get().InvocationType,
-                                 invocation_type);
-  request_headers_->addReference(AWSLambdaHeaderNames::get().LogType,
-                                 AWSLambdaHeaderNames::get().LogNone);
-  request_headers_->setReferenceHost(protocol_options_->host());
+  updateHeaders();
 
   aws_authenticator_.sign(request_headers_, HeadersToSign,
                           protocol_options_->region());

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.h
@@ -97,6 +97,7 @@ private:
                           const Buffer::Instance&, Buffer::Instance&);
   bool isResponseTransformationNeeded();
   bool isRequestTransformationNeeded();
+  void updateHeaders();
   void transformRequest();
 
   Http::RequestHeaderMap *request_headers_{};

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_transformer_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_transformer_test.cc
@@ -189,6 +189,10 @@ TEST_F(AWSLambdaTransformerTest, TestConfigureRequestTransformer){
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, true));
   // Confirm that the body contains the expected value as a substring
   EXPECT_THAT(upstream_body, testing::HasSubstr("test body from fake transformer"));
+  // Confirm that the headers are present in the response body
+  EXPECT_THAT(upstream_body, testing::HasSubstr(":method; GET"));
+  EXPECT_THAT(upstream_body, testing::HasSubstr(":authority; www.solo.io"));
+  EXPECT_THAT(upstream_body, testing::HasSubstr(":path; /getsomething"));
 }
 
 TEST_F(AWSLambdaTransformerTest, TestConfigureRequestTransformerSignature){

--- a/test/extensions/filters/http/aws_lambda/aws_lambda_transformer_test.cc
+++ b/test/extensions/filters/http/aws_lambda/aws_lambda_transformer_test.cc
@@ -187,8 +187,8 @@ TEST_F(AWSLambdaTransformerTest, TestConfigureRequestTransformer){
       }));
 
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, true));
-  // Confirm that the body is transformed to the hardcoded string.
-  EXPECT_EQ(upstream_body, "test body from fake transformer");
+  // Confirm that the body contains the expected value as a substring
+  EXPECT_THAT(upstream_body, testing::HasSubstr("test body from fake transformer"));
 }
 
 TEST_F(AWSLambdaTransformerTest, TestConfigureRequestTransformerSignature){
@@ -254,7 +254,7 @@ TEST_F(AWSLambdaTransformerTest, TestConfigureRequestTransformerSignatureNoBody)
 
 
   EXPECT_EQ(transformedxAmzDateHeader[0]->value().getStringView(), "20010909T014640Z");
-  EXPECT_EQ(transformedAuthorizationHeader[0]->value().getStringView(), "AWS4-HMAC-SHA256 Credential=access key/20010909/us-east-1/lambda/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-invocation-type;x-amz-log-type, Signature=561409e1250c56044b11a3d6eaed9f3d3d9467f3214dfec4786a65381bdab23e");
+  EXPECT_EQ(transformedAuthorizationHeader[0]->value().getStringView(), "AWS4-HMAC-SHA256 Credential=access key/20010909/us-east-1/lambda/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-invocation-type;x-amz-log-type, Signature=31e8a35e5818a5a1b969bc5d80e48d10f5478c12d67cbbace4472a1566ede502");
 
   // now, setup to use no transformer
   setupRoute(false, false);
@@ -292,7 +292,7 @@ TEST_F(AWSLambdaTransformerTest, TestConfigureResponseTransformer){
   auto edResult = filter_->encodeData(dataBuf, true);
 
   EXPECT_EQ(Http::FilterDataStatus::Continue, edResult);
-  EXPECT_STREQ("test body from fake transformer", buf.toString().c_str());
+  EXPECT_THAT(buf.toString().c_str(), testing::HasSubstr("test body from fake transformer"));
 }
 
 TEST_F(AWSLambdaTransformerTest, TestNoBodyRequestTransformation){
@@ -310,7 +310,7 @@ TEST_F(AWSLambdaTransformerTest, TestNoBodyRequestTransformation){
   auto transformedxAmzDateHeader = headers.get(Http::LowerCaseString("x-amz-date"));
 
   EXPECT_EQ(transformedxAmzDateHeader[0]->value().getStringView(), "20010909T014640Z");
-  EXPECT_EQ(transformedAuthorizationHeader[0]->value().getStringView(), "AWS4-HMAC-SHA256 Credential=access key/20010909/us-east-1/lambda/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-invocation-type;x-amz-log-type, Signature=561409e1250c56044b11a3d6eaed9f3d3d9467f3214dfec4786a65381bdab23e");
+  EXPECT_EQ(transformedAuthorizationHeader[0]->value().getStringView(), "AWS4-HMAC-SHA256 Credential=access key/20010909/us-east-1/lambda/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-invocation-type;x-amz-log-type, Signature=31e8a35e5818a5a1b969bc5d80e48d10f5478c12d67cbbace4472a1566ede502");
 }
 
 } // namespace AwsLambda

--- a/test/extensions/filters/http/aws_lambda/test_transformer.h
+++ b/test/extensions/filters/http/aws_lambda/test_transformer.h
@@ -22,6 +22,7 @@ public:
                                 [headers_string](const Http::HeaderEntry &header) -> Http::HeaderMap::Iterate {
                                     auto key = std::string(header.key().getStringView());
                                     auto value = std::string(header.value().getStringView());
+                                    // use semicolon as a separator, because pseudo-headers (e.g. :path) have colons (":") in them
                                     *headers_string += "\t" + key + "; " + value + "\n";
                                     return Http::HeaderMap::Iterate::Continue;
                                 });

--- a/test/extensions/filters/http/aws_lambda/test_transformer.h
+++ b/test/extensions/filters/http/aws_lambda/test_transformer.h
@@ -13,12 +13,22 @@ class FakeTransformer : public HttpFilters::Transformation::Transformer {
 public:
   bool passthrough_body() const override {return false;}
   // This transformer just drains the body and replaces it with a hardcoded string.
-  void transform (Http::RequestOrResponseHeaderMap &,
+  void transform (Http::RequestOrResponseHeaderMap &headers,
                          Http::RequestHeaderMap *,
                          Buffer::Instance &body,
                          Http::StreamFilterCallbacks &) const override {
+                            std::string *headers_string = new std::string("headers:\n");
+                            headers.iterate(
+                                [headers_string](const Http::HeaderEntry &header) -> Http::HeaderMap::Iterate {
+                                    auto key = std::string(header.key().getStringView());
+                                    auto value = std::string(header.value().getStringView());
+                                    *headers_string += "\t" + key + "; " + value + "\n";
+                                    return Http::HeaderMap::Iterate::Continue;
+                                });
+
+                            std::string bodyString = "test body from fake transformer\n" + *headers_string;
                             body.drain(body.length());
-                            body.add("test body from fake transformer");
+                            body.add(bodyString);
   }
 
 };


### PR DESCRIPTION
# Description
 - This PR resolves an issue when processing request transformations in the AWS lambda filter.
   - Prior to this change, the AWS lambda filter would modify the `:path` and `:method` pseudo-headers before the request transformation was processed, resulting in the upstream receiving invalid values of these headers.
 - Once this change is pulled into enterprise, users will be receive valid path/querystringparams/method values when configuring `wrapAsApiGateway`

# Implementation Details
 - Adds a new helper, `AWSLambdaFilter::updateHeaders`, which is used to ensure that all headers which need to be modified for the sake of routing to AWS can be modified in the same place. This method is called immediately after request transformations are processed
 - The test transformer used in `aws_lambda_transformer_test.cc` now places the headers it receives in the request body, allowing us to validate the headers used by request (and response) transformations
   - Because of this, tests which expect a specific signature to be outputted from this transformer need to be updated, as the signature is computed directly from the request body sent to AWS