### PR TITLE
Refactor transformations for request/response/onStreamComplete

### DIFF
--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -192,6 +192,7 @@ void AWSLambdaFilter::finalizeResponse(){
       auto transformer_config = functionOnRoute()->transformerConfig();
       transformer_config->transform(
         *response_headers_,
+        request_headers_,
         enc_buf,
         *encoder_callbacks_
       );

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -211,7 +211,7 @@ void TransformationFilter::transformRequest() {
 void TransformationFilter::transformResponse() {
   std::cout << "1" << std::endl;
   try {
-    response_transformation_->transform(*response_headers_, response_body_, *decoder_callbacks_);
+    response_transformation_->transform(*response_headers_, request_headers_, response_body_, *decoder_callbacks_);
   } catch (const std::exception &e) {
     error(Error::TemplateParseError, e.what());
     ENVOY_STREAM_LOG(debug,
@@ -257,7 +257,7 @@ void TransformationFilter::transformOnStreamCompletion() {
 
   try {
     std::cout << "!3" << std::endl;
-    on_stream_completion_transformation_->transform(*response_headers_,*request_headers_, emptyBody, *encoder_callbacks_);
+    on_stream_completion_transformation_->transform(*response_headers_, request_headers_, emptyBody, *encoder_callbacks_);
     std::cout << "!4" << std::endl;
   } catch (std::exception &e)  {
     error(Error::TemplateParseError, e.what());

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.cc
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.cc
@@ -49,6 +49,7 @@ void ApiGatewayTransformer::format_error(
 
 void ApiGatewayTransformer::transform(
     Http::ResponseHeaderMap &response_headers,
+    Http::RequestHeaderMap *,
     Buffer::Instance &body,
     Http::StreamFilterCallbacks &stream_filter_callbacks) const {
       ENVOY_STREAM_LOG(debug, "Transforming response", stream_filter_callbacks);

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
@@ -44,6 +44,7 @@ class ApiGatewayTransformer : public Transformation::ResponseTransformer, Logger
 public:
   ApiGatewayTransformer();
   void transform(Http::ResponseHeaderMap &response_headers,
+                 Http::RequestHeaderMap *request_headers,
                  Buffer::Instance &body,
                  Http::StreamFilterCallbacks &) const override;
   void transform_response(Http::ResponseHeaderMap &response_headers,

--- a/test/extensions/filters/http/transformation/fake_transformer.h
+++ b/test/extensions/filters/http/transformation/fake_transformer.h
@@ -31,6 +31,7 @@ class FakeResponseTransformer : public FakeTransformer, public ResponseTransform
 public:
   bool passthrough_body() const override {return false;}
   void transform (Http::ResponseHeaderMap &,
+                  Http::RequestHeaderMap *,
                   Buffer::Instance &,
                   Http::StreamFilterCallbacks &) const override {
   }
@@ -41,7 +42,7 @@ class FakeOnStreamCompleteTransformer : public FakeTransformer, public OnStreamC
 public:
   bool passthrough_body() const override {return false;}
   void transform (Http::ResponseHeaderMap &,
-                  Http::RequestHeaderMap &,
+                  Http::RequestHeaderMap *,
                   Buffer::Instance &,
                   Http::StreamFilterCallbacks &) const override {
   }


### PR DESCRIPTION
Refactor transformation filter to introduce discrete Transformers for request path, response path, and onstreamcomplete. This will provide config-time safety for transformers that are only valid to be run in a particular case instead of guarding at runtime.