### PR TITLE
Dynamic metadata filter chain v1.25

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,8 +1,9 @@
 REPOSITORY_LOCATIONS = dict(
     # envoy 1.25.1, commit: https://github.com/envoyproxy/envoy/commit/8eca7df5099ee383f1beb37f54427957411d0936
     envoy = dict(
-        commit = "8eca7df5099ee383f1beb37f54427957411d0936",
-        remote = "https://github.com/envoyproxy/envoy",
+        # envoy fork with dynamic metadata in matching data inputs
+        commit = "71359920812f13130e657c25913c8b174852daf4",
+        remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(
         commit = "4c0ee3a46c0bbb279b0849e5a659e52684a37a98",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,8 +1,11 @@
 REPOSITORY_LOCATIONS = dict(
-    # envoy 1.25.1, commit: https://github.com/envoyproxy/envoy/commit/8eca7df5099ee383f1beb37f54427957411d0936
     envoy = dict(
-        # envoy fork with dynamic metadata in matching data inputs
-        commit = "71359920812f13130e657c25913c8b174852daf4",
+        # envoy fork starting from 1.25.4 with cherry-picks:
+        # https://github.com/envoyproxy/envoy/pull/25856
+        #   ^ add filter state matching input
+        # https://github.com/envoyproxy/envoy/pull/26311
+        #   ^ add dynamic metadata to MatchingData
+        commit = "fa3b44a537def7ab966e2192e2693be9bede0446",
         remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -3,8 +3,11 @@ REPOSITORY_LOCATIONS = dict(
         # envoy fork starting from 1.25.4 with cherry-picks:
         # https://github.com/envoyproxy/envoy/pull/25856
         #   ^ add filter state matching input
+        #     https://github.com/envoyproxy/envoy/commit/f52d559e0479824b9c964e4c028fa373bcb9b767
         # https://github.com/envoyproxy/envoy/pull/26311
         #   ^ add dynamic metadata to MatchingData
+        #     https://github.com/solo-io/envoy-fork/commit/71359920812f13130e657c25913c8b174852daf4
+        #     https://github.com/ashishb-solo/envoy/tree/ashishb-solo/add-dynamic-metadata-to-matchingdata
         commit = "fa3b44a537def7ab966e2192e2693be9bede0446",
         remote = "https://github.com/solo-io/envoy-fork",
     ),

--- a/changelog/v1.25.4-patch2/fork-envoy-for-dcp.yaml
+++ b/changelog/v1.25.4-patch2/fork-envoy-for-dcp.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/solo-projects/issues/4634
+  resolvesIssue: false
+  description: >-
+    Fork envoy and incorporate a few patches to support the deprecated cipher
+    passthrough work. Specifically, enable parsing dynamic metadata in filter
+    chain input matchers.


### PR DESCRIPTION
Incorporate some cherry-picks off envoy-v1.26 related to deprecated cipher passthrough work.