### PR TITLE
Double-URL-Encode ARN to unblock resource-based cross-account Lambda Invocation

### DIFF
--- a/changelog/v1.25.4-patch3/double-encode-fix.yaml
+++ b/changelog/v1.25.4-patch3/double-encode-fix.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/7965
+  description: >
+    Addresses a bug that blocked the resource-based cross-account Lambda workflow.
+    Essentially, the AWS Lambda API expects the ARN to be URL encoded twice. We were
+    only encoding it once, which caused the API to reject the request.

--- a/changelog/v1.25.4-patch3/double-encode-fix.yaml
+++ b/changelog/v1.25.4-patch3/double-encode-fix.yaml
@@ -1,6 +1,7 @@
 changelog:
 - type: FIX
   issueLink: https://github.com/solo-io/gloo/issues/7965
+  resolvesIssue: false
   description: >
     Addresses a bug that blocked the resource-based cross-account Lambda workflow.
     Essentially, the AWS Lambda API expects the ARN to be URL encoded twice. We were

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
@@ -132,25 +132,16 @@ std::string AwsAuthenticator::getBodyHexSha() {
   return hexpayload;
 }
 
-void AwsAuthenticator::setUrlBase(std::string url_base) {
-  url_base_ = url_base;
-}
-
 void AwsAuthenticator::fetchUrl() {
-  // if url_base_ is not defined, set it to the value of the path request header
-  if (url_base_.empty()) {
-    const Http::HeaderString &path = request_headers_->Path()->value();
-    url_base_ = std::string(path.getStringView());
-  }
-
-  absl::string_view query_string_view = Http::Utility::findQueryStringStart(Http::HeaderString(url_base_));
-  query_string_ = std::string(query_string_view);
+  const Http::HeaderString &canonical_url = request_headers_->Path()->value();
+  
+  url_base_ = std::string(canonical_url.getStringView());
+  query_string_ = std::string(Http::Utility::findQueryStringStart(canonical_url));
   if (query_string_.length() != 0) {
     // remove the query string from the url_base
     url_base_ = url_base_.substr(0, url_base_.length() - query_string_.length());
     // remove the ? from the query string
     query_string_ = query_string_.substr(1);
-    std::cout << "query string is " << query_string_ << std::endl;
   }
 
   // although the URL base is already encode it, due to a bug in AWS we need to encode it again

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
@@ -201,7 +201,6 @@ AwsAuthenticator::getCredntialScope(const std::string &region,
   return credential_scope_stream.str();
 }
 
-// NTS: we compute signatures here
 std::string AwsAuthenticator::computeSignature(
     const std::string &region, const std::string &credentials_scope_date,
     const std::string &credential_scope, const std::string &request_date_time,

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.h
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.h
@@ -57,6 +57,8 @@ public:
 
   std::string getBodyHexSha();
 
+  void setUrlBase(std::string url_base);
+
 private:
   // TODO(yuval-k) can I refactor our the friendliness?
   friend class AwsAuthenticatorTest;
@@ -139,8 +141,8 @@ private:
   std::string first_key_;
   const std::string *service_{};
   const std::string *method_{};
-  absl::string_view query_string_{};
-  absl::string_view url_base_{};
+  std::string query_string_{};
+  std::string url_base_{};
 
   Http::RequestHeaderMap *request_headers_{};
 };

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.h
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.h
@@ -57,8 +57,6 @@ public:
 
   std::string getBodyHexSha();
 
-  void setUrlBase(std::string url_base);
-
 private:
   // TODO(yuval-k) can I refactor our the friendliness?
   friend class AwsAuthenticatorTest;

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -381,7 +381,6 @@ void AWSLambdaFilter::finalizeRequest() {
   }
   updateHeaders();
 
-  aws_authenticator_.setUrlBase(functionOnRoute()->path());
   aws_authenticator_.sign(request_headers_, HeadersToSign,
                           protocol_options_->region());
 }

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -381,6 +381,7 @@ void AWSLambdaFilter::finalizeRequest() {
   }
   updateHeaders();
 
+  aws_authenticator_.setUrlBase(functionOnRoute()->path());
   aws_authenticator_.sign(request_headers_, HeadersToSign,
                           protocol_options_->region());
 }


### PR DESCRIPTION
# Description
 - Addresses a bug that blocked the resource-based cross-account Lambda workflow. Essentially, the AWS Lambda API expects the ARN to be URL encoded twice. We were only encoding it once, which caused the API to reject the request.
   - This bug only affected the resource-based cross-account Lambda workflow, as this is the only Lambda workflow that uses a fully-qualified ARN to address the target Lambda. All other workflows use the Lambda function name to address the target. Because the Lambda function name doesn't contain characters that must be escaped, they are unaffected by this issue
 - The solution is to URL-encode the (already URL-encoded) `url_base_` variable in the AWS Authenticator before forming the canonical request, so that we match the behavior expected by AWS
   - We have to ensure that we don't double encode the actual `:path` request pseudo-header, as this will cause routing issues.

# Background
 - Our AWS Lambda filter invokes Lambda functions over HTTP by using signed AWS API Requests (see [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html))
 - In order to interact with this API, we need to form a canonical request, which is a string that contains all the information about the request that is required for AWS to validate the request
 - The canonical request is formed by concatenating the following:
   - The HTTP method
   - The canonical URI
   - The canonical query string
   - The canonical headers
   - The signed headers
   - The hashed payload
 - In what is probably a bug in the AWS Lambda API, the canonical URI must be double URL-encoded. This is not documented anywhere, but is required for the API to accept the request
   - For example, if we want to invoke the lambda at `arn:aws:lambda:us-east-1:123456789012:function:my-function`, we have to send a request to `https://lambda.us-east-1.amazonaws.com/2015-03-31/functions/arn%3Aaws%3Alambda%3Aus-east-1%3A123456789012%3Afunction%3Amy-function/invocations` (this is a single-URL-encoded version of the URI, as one would expect). However, the canonical URI in the canonical request must be `2015-03-31/functions/arn%253Aaws%253Alambda%253Aus-east-1%253A123456789012%253Afunction%253Amy-function/invocations` (this is a double-URL-encoded version of the URI, which is required for the API to accept the request) 
   - I was able to identify this discrepancy by using the AWS CLI with the `--debug` flag set. You can call `aws lambda invoke ... --debug` and it will send the same signed AWS API requests that our envoy Lambda filter does. The debug option will log the canonical request sent to the upstream server, which revealed that the canonical URI is double-encoded