### PR TITLE
POC: Added replace_with_random() for substitutions in templates

### DIFF
--- a/source/extensions/filters/http/transformation/BUILD
+++ b/source/extensions/filters/http/transformation/BUILD
@@ -91,6 +91,7 @@ envoy_cc_library(
         "@envoy//source/common/common:regex_lib",
         "@envoy//source/common/common:utility_lib",
         "@envoy//source/common/protobuf",
+	"@envoy//source/common/common:random_generator_lib",
         "@inja//:inja-lib",
         "@json//:json-lib",
     ],

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -6,6 +6,7 @@
 #include "envoy/http/header_map.h"
 
 #include "source/common/common/base64.h"
+#include "source/common/common/random_generator.h"
 
 #include "source/extensions/filters/http/transformation/transformer.h"
 
@@ -47,6 +48,8 @@ private:
   nlohmann::json base64_encode_callback(const inja::Arguments &args) const;
   nlohmann::json base64_decode_callback(const inja::Arguments &args) const;
   nlohmann::json substring_callback(const inja::Arguments &args) const;
+  nlohmann::json replace_with_random_callback(const inja::Arguments &args);
+  int random_for_pattern(const std::string& pattern);
 
   inja::Environment env_;
   const Http::RequestOrResponseHeaderMap &header_map_;
@@ -56,6 +59,8 @@ private:
   const nlohmann::json &context_;
   const std::unordered_map<std::string, std::string> &environ_;
   const envoy::config::core::v3::Metadata *cluster_metadata_;
+  std::unordered_map<std::string, int> pattern_replacements_;
+  Envoy::Random::RandomGeneratorImpl rng_;
 };
 
 class Extractor : Logger::Loggable<Logger::Id::filter> {


### PR DESCRIPTION
A test transformation policy. Please note use of `replace_with_random` in `baz` header and in the response body:
```
kmgmt apply -f- <<EOF
apiVersion: trafficcontrol.policy.gloo.solo.io/v2
kind: TransformationPolicy
metadata:
  annotations:
    cluster.solo.io/cluster: ""
  name: transformation-1
  namespace: bookinfo
spec:
  applyToRoutes:
  - route:
      labels:
        route: ratings
  config:
    phase:
      postAuthz:
        priority: 10
    response:
      injaTemplate:
        advancedTemplates: false
        parseBodyBehavior: DontParse
        extractors:
          content-suffix:
            header: content-type
            regex: .*
        headers:
          baz:
            text: '{{ replace_with_random(content-suffix, "json") }}'          
          foo:
            text: bar
        body:
          text: ' {{ replace_with_random(body(), "Reviewer") }}'
EOF
```
An example without application of the transformation policy:
```
[wb@solo-system-ddolguikh proxy]$ curl -i -H"host: www.example.com" http://${INGRESS_GW_IP}:${INGRESS_PORT}/ratings/1
HTTP/1.1 200 OK
content-type: application/json
date: Fri, 19 May 2023 23:37:35 GMT
x-envoy-upstream-service-time: 0
server: istio-envoy
transfer-encoding: chunked

{"id":1,"ratings":{"Reviewer1":5,"Reviewer2":4}}
```

Same, but with the transformation policy applied. In `baz` header, the value of content-type header was used as the source string and the `json` part replaced with a random string. In the body `Reviewer` pattern was replaced with a random one.
```
[wb@solo-system-ddolguikh proxy]$ curl -i -H"host: www.example.com" http://${INGRESS_GW_IP}:${INGRESS_PORT}/ratings/1
HTTP/1.1 200 OK
content-type: application/json
date: Fri, 19 May 2023 23:33:09 GMT
x-envoy-upstream-service-time: 1
baz: application/1715106686
foo: bar
content-length: 53
server: istio-envoy

 {"id":1,"ratings":{"-6778386221":5,"-6778386222":4}}
```

Remaining questions:
 - Do we want to support multiple transformation policies per phase? Strictly speaking not necessary for this work, but there appears to be interest (see this thread: https://solo-io-corp.slack.com/archives/CHAC8587L/p1684511829499599), Support for multiple transformation policies per phase can probably be handled as a separate feature though.
 - what's the format for the replacement string? I don't think we want signed ints there though. Envoy's random number generator supports generation of uuids natively, if that's what we want to do.
 - `replace_with_random` function is a bit awkward, as it requires a source string as a parameter. Could implement it as a variadic-type function and populate a "special" var in the template context as a default source. For headers it would be the current header value, for the body -- the body itself. 