### PR TITLE
Expand Transformation Logging

### DIFF
--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -23,6 +23,8 @@ message FilterTransformations {
   // Only RouteTransformations.RouteTransformation with matching stage will be
   // used with this filter.
   uint32 stage = 2 [ (validate.rules).uint32 = {lte : 10} ];
+
+  bool log_request_response_info = 3;
 }
 
 message TransformationRule {

--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -127,6 +127,8 @@ message Transformation {
     // Configuration for an externally implemented transformer.
     envoy.config.core.v3.TypedExtensionConfig transformer_config = 3;
   }
+
+  bool log_request_response_info = 4;
 }
 
 // Extractions can be used to extract information from the request/response.

--- a/changelog/v1.25.4-patch3/double-encode-fix.yaml
+++ b/changelog/v1.25.4-patch3/double-encode-fix.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/7965
+  description: >
+    Addresses a bug that blocked the resource-based cross-account Lambda workflow.
+    Essentially, the AWS Lambda API expects the ARN to be URL encoded twice. We were
+    only encoding it once, which caused the API to reject the request.

--- a/changelog/v1.25.4-patch3/double-encode-fix.yaml
+++ b/changelog/v1.25.4-patch3/double-encode-fix.yaml
@@ -1,6 +1,7 @@
 changelog:
 - type: FIX
   issueLink: https://github.com/solo-io/gloo/issues/7965
+  resolvesIssue: false
   description: >
     Addresses a bug that blocked the resource-based cross-account Lambda workflow.
     Essentially, the AWS Lambda API expects the ARN to be URL encoded twice. We were

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
@@ -132,25 +132,16 @@ std::string AwsAuthenticator::getBodyHexSha() {
   return hexpayload;
 }
 
-void AwsAuthenticator::setUrlBase(std::string url_base) {
-  url_base_ = url_base;
-}
-
 void AwsAuthenticator::fetchUrl() {
-  // if url_base_ is not defined, set it to the value of the path request header
-  if (url_base_.empty()) {
-    const Http::HeaderString &path = request_headers_->Path()->value();
-    url_base_ = std::string(path.getStringView());
-  }
-
-  absl::string_view query_string_view = Http::Utility::findQueryStringStart(Http::HeaderString(url_base_));
-  query_string_ = std::string(query_string_view);
+  const Http::HeaderString &canonical_url = request_headers_->Path()->value();
+  
+  url_base_ = std::string(canonical_url.getStringView());
+  query_string_ = std::string(Http::Utility::findQueryStringStart(canonical_url));
   if (query_string_.length() != 0) {
     // remove the query string from the url_base
     url_base_ = url_base_.substr(0, url_base_.length() - query_string_.length());
     // remove the ? from the query string
     query_string_ = query_string_.substr(1);
-    std::cout << "query string is " << query_string_ << std::endl;
   }
 
   // although the URL base is already encode it, due to a bug in AWS we need to encode it again

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.cc
@@ -201,7 +201,6 @@ AwsAuthenticator::getCredntialScope(const std::string &region,
   return credential_scope_stream.str();
 }
 
-// NTS: we compute signatures here
 std::string AwsAuthenticator::computeSignature(
     const std::string &region, const std::string &credentials_scope_date,
     const std::string &credential_scope, const std::string &request_date_time,

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.h
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.h
@@ -57,6 +57,8 @@ public:
 
   std::string getBodyHexSha();
 
+  void setUrlBase(std::string url_base);
+
 private:
   // TODO(yuval-k) can I refactor our the friendliness?
   friend class AwsAuthenticatorTest;
@@ -139,8 +141,8 @@ private:
   std::string first_key_;
   const std::string *service_{};
   const std::string *method_{};
-  absl::string_view query_string_{};
-  absl::string_view url_base_{};
+  std::string query_string_{};
+  std::string url_base_{};
 
   Http::RequestHeaderMap *request_headers_{};
 };

--- a/source/extensions/filters/http/aws_lambda/aws_authenticator.h
+++ b/source/extensions/filters/http/aws_lambda/aws_authenticator.h
@@ -57,8 +57,6 @@ public:
 
   std::string getBodyHexSha();
 
-  void setUrlBase(std::string url_base);
-
 private:
   // TODO(yuval-k) can I refactor our the friendliness?
   friend class AwsAuthenticatorTest;

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -381,7 +381,6 @@ void AWSLambdaFilter::finalizeRequest() {
   }
   updateHeaders();
 
-  aws_authenticator_.setUrlBase(functionOnRoute()->path());
   aws_authenticator_.sign(request_headers_, HeadersToSign,
                           protocol_options_->region());
 }

--- a/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
+++ b/source/extensions/filters/http/aws_lambda/aws_lambda_filter.cc
@@ -381,6 +381,7 @@ void AWSLambdaFilter::finalizeRequest() {
   }
   updateHeaders();
 
+  aws_authenticator_.setUrlBase(functionOnRoute()->path());
   aws_authenticator_.sign(request_headers_, HeadersToSign,
                           protocol_options_->region());
 }

--- a/source/extensions/filters/http/transformation/BUILD
+++ b/source/extensions/filters/http/transformation/BUILD
@@ -11,6 +11,16 @@ load(
 envoy_package()
 
 envoy_cc_library(
+    name = "transformation_logger_lib",
+    hdrs = ["transformation_logger.h"],
+    srcs = ["transformation_logger.cc"],
+    deps = [
+        "@envoy//source/common/common:minimal_logger_lib"
+    ],
+    repository = "@envoy",
+)
+
+envoy_cc_library(
     name = "transformation_filter_config",
     srcs = [
         "transformation_filter_config.cc",
@@ -23,6 +33,7 @@ envoy_cc_library(
         ":body_header_transformer_lib",
         ":inja_transformer_lib",
         ":transformer_lib",
+        ":transformation_logger_lib",
         "//source/extensions/filters/http:solo_well_known_names",
         "//api/envoy/config/filter/http/transformation/v2:pkg_cc_proto",
         "@envoy//envoy/router:router_interface",

--- a/source/extensions/filters/http/transformation/body_header_transformer.cc
+++ b/source/extensions/filters/http/transformation/body_header_transformer.cc
@@ -13,7 +13,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Transformation {
 
-BodyHeaderTransformer::BodyHeaderTransformer(bool add_request_metadata):add_request_metadata_(add_request_metadata){}
+BodyHeaderTransformer::BodyHeaderTransformer(bool add_request_metadata, bool log_request_response_info)
+    : Transformer(log_request_response_info), add_request_metadata_(add_request_metadata){}
 
 void BodyHeaderTransformer::transform(
     Http::RequestOrResponseHeaderMap &header_map,

--- a/source/extensions/filters/http/transformation/body_header_transformer.h
+++ b/source/extensions/filters/http/transformation/body_header_transformer.h
@@ -11,7 +11,7 @@ namespace Transformation {
 
 class BodyHeaderTransformer : public Transformer {
 public:
-  BodyHeaderTransformer(bool add_request_metadata);
+  BodyHeaderTransformer(bool add_request_metadata, bool log_request_response_info);
   void transform(Http::RequestOrResponseHeaderMap &map,
                  Http::RequestHeaderMap *request_headers,
                  Buffer::Instance &body,

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -323,11 +323,13 @@ std::string TransformerInstance::render(const inja::Template &input) {
   }
 }
 
-InjaTransformer::InjaTransformer(const TransformationTemplate &transformation)
-    : advanced_templates_(transformation.advanced_templates()),
+InjaTransformer::InjaTransformer(const TransformationTemplate &transformation, bool log_request_response_info)
+    : Transformer(log_request_response_info),
+      advanced_templates_(transformation.advanced_templates()),
       passthrough_body_(transformation.has_passthrough()),
       parse_body_behavior_(transformation.parse_body_behavior()),
-      ignore_error_on_parse_(transformation.ignore_error_on_parse()) {
+      ignore_error_on_parse_(transformation.ignore_error_on_parse())
+       {
   inja::ParserConfig parser_config;
   inja::LexerConfig lexer_config;
   inja::TemplateStorage template_storage;

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -78,7 +78,7 @@ private:
 class InjaTransformer : public Transformer {
 public:
   InjaTransformer(const envoy::api::v2::filter::http::TransformationTemplate
-                      &transformation);
+                      &transformation, bool log_request_response_info);
   ~InjaTransformer();
 
   void transform(Http::RequestOrResponseHeaderMap &map,

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -253,12 +253,13 @@ void TransformationFilter::transformSomething(
   try {
     // if log_request_response_info_ is set on the transformation, log the
     // request body and request headers before transformation
-    TRANSFORMATION_LOG_IF(debug, transformation->logRequestResponseInfo(),
-                          "headers before transformation: {}",
-                          callbacks, header_map);
-    TRANSFORMATION_LOG_IF(debug, transformation->logRequestResponseInfo(),
-                          "body before transformation: {}",
-                          callbacks, body);
+    auto log_condition = filter_config_->logRequestResponseInfo() || transformation->logRequestResponseInfo();
+    TRANSFORMATION_LOG_IF(debug, log_condition,
+                          "headers before transformation: {}", callbacks,
+                          header_map);
+    TRANSFORMATION_LOG_IF(debug, log_condition,
+                          "body before transformation: {}", callbacks,
+                          body.toString());
     transformation->transform(header_map, request_headers_, body, callbacks);
 
     if (body.length() > 0) {

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -9,6 +9,7 @@
 
 #include "source/extensions/filters/http/solo_well_known_names.h"
 #include "source/extensions/filters/http/transformation/transformer.h"
+#include "source/extensions/filters/http/transformation/transformation_logger.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -250,6 +251,14 @@ void TransformationFilter::transformSomething(
     void (TransformationFilter::*addData)(Buffer::Instance &)) {
 
   try {
+    // if log_request_response_info_ is set on the transformation, log the
+    // request body and request headers before transformation
+    TRANSFORMATION_LOG_IF(debug, transformation->logRequestResponseInfo(),
+                          "headers before transformation: {}",
+                          callbacks, header_map);
+    TRANSFORMATION_LOG_IF(debug, transformation->logRequestResponseInfo(),
+                          "body before transformation: {}",
+                          callbacks, body);
     transformation->transform(header_map, request_headers_, body, callbacks);
 
     if (body.length() > 0) {

--- a/source/extensions/filters/http/transformation/transformation_filter_config.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.cc
@@ -44,7 +44,7 @@ TransformerConstSharedPtr Transformation::getTransformer(
 TransformationFilterConfig::TransformationFilterConfig(
     const TransformationConfigProto &proto_config, const std::string &prefix,
     Server::Configuration::FactoryContext &context)
-    : FilterConfig(prefix, context.scope(), proto_config.stage()) {
+    : FilterConfig(prefix, context.scope(), proto_config.stage(), proto_config.log_request_response_info()) {
 
   for (const auto &rule : proto_config.transformations()) {
     if (!rule.has_match()) {

--- a/source/extensions/filters/http/transformation/transformation_filter_config.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.cc
@@ -21,14 +21,15 @@ TransformerConstSharedPtr Transformation::getTransformer(
   switch (transformation.transformation_type_case()) {
   case envoy::api::v2::filter::http::Transformation::kTransformationTemplate:
     return std::make_unique<InjaTransformer>(
-        transformation.transformation_template());
+        transformation.transformation_template(), transformation.log_request_response_info());
   case envoy::api::v2::filter::http::Transformation::kHeaderBodyTransform: {
     const auto& header_body_transform = transformation.header_body_transform();
-    return std::make_unique<BodyHeaderTransformer>(header_body_transform.add_request_metadata());
+    return std::make_unique<BodyHeaderTransformer>(header_body_transform.add_request_metadata(), transformation.log_request_response_info());
   }
   case envoy::api::v2::filter::http::Transformation::kTransformerConfig: {
     auto &factory = Config::Utility::getAndCheckFactory<TransformerExtensionFactory>(transformation.transformer_config());
     auto config = Config::Utility::translateAnyToFactoryConfig(transformation.transformer_config().typed_config(), context.messageValidationContext().staticValidationVisitor(), factory);
+    // TODO: need to validate this case
     return factory.createTransformer(*config, context);
   }
   case envoy::api::v2::filter::http::Transformation::

--- a/source/extensions/filters/http/transformation/transformation_filter_config.h
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.h
@@ -58,9 +58,15 @@ public:
     return SoloHttpFilterNames::get().Transformation;
   }
 
+  bool logRequestResponseInfo() const {
+    return log_request_response_info_;
+  }
+
 private:
   // The list of transformer matchers.
   std::vector<MatcherTransformerPair> transformer_pairs_{};
+
+  bool log_request_response_info_{};
 };
 
 class PerStageRouteTransformationFilterConfig : public TransformConfig {

--- a/source/extensions/filters/http/transformation/transformation_logger.cc
+++ b/source/extensions/filters/http/transformation/transformation_logger.cc
@@ -1,0 +1,1 @@
+#include "source/extensions/filters/http/transformation/transformation_logger.h"

--- a/source/extensions/filters/http/transformation/transformation_logger.h
+++ b/source/extensions/filters/http/transformation/transformation_logger.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "source/common/common/logger.h"
+
+// TODO: remove logs to stdout
+#define TRANSFORMATION_LOG(LEVEL, FORMAT, STREAM, ...)                  \
+  do {                                                                  \
+      ENVOY_STREAM_LOG(LEVEL, FORMAT, STREAM, ##__VA_ARGS__);           \
+      std::cout << "REQUEST_RESPONSE_LOG: " << FORMAT << std::endl;     \
+  } while (0)
+
+#define TRANSFORMATION_LOG_IF(LEVEL, CONDITION, FORMAT, STREAM, ...)        \
+    do {                                                                    \
+        if (CONDITION) {                                                    \
+            TRANSFORMATION_LOG(LEVEL, FORMAT, STREAM, ##__VA_ARGS__);       \
+        }                                                                   \
+    } while (0)
+
+#define TRANSFORMATION_SENSITIVE_LOG(LEVEL, FORMAT, PARAMS, ...)                               \
+    do {                                                                                       \
+        TRANSFORMATION_LOG_IF(true, LEVEL, FORMAT, (PARAMS).stream_callbacks_, ##__VA_ARGS__); \
+    } while (0)

--- a/source/extensions/filters/http/transformation/transformation_logger.h
+++ b/source/extensions/filters/http/transformation/transformation_logger.h
@@ -2,7 +2,6 @@
 
 #include "source/common/common/logger.h"
 
-// TODO: remove logs to stdout
 #define TRANSFORMATION_LOG(LEVEL, FORMAT, STREAM, ...)                  \
   do {                                                                  \
       ENVOY_STREAM_LOG(LEVEL, FORMAT, STREAM, ##__VA_ARGS__);           \

--- a/source/extensions/filters/http/transformation/transformer.h
+++ b/source/extensions/filters/http/transformation/transformer.h
@@ -129,8 +129,8 @@ private:
 
 class FilterConfig : public TransformConfig {
 public:
-  FilterConfig(const std::string &prefix, Stats::Scope &scope, uint32_t stage)
-      : stats_(generateStats(prefix, scope)), stage_(stage){};
+  FilterConfig(const std::string &prefix, Stats::Scope &scope, uint32_t stage, bool log_request_response_info)
+      : stats_(generateStats(prefix, scope)), stage_(stage), log_request_response_info_(log_request_response_info) {}
 
   static TransformationFilterStats generateStats(const std::string &prefix,
                                                  Stats::Scope &scope);
@@ -154,9 +154,12 @@ public:
 
   uint32_t stage() const { return stage_; }
 
+  bool logRequestResponseInfo() const { return log_request_response_info_; }
+
 private:
   TransformationFilterStats stats_;
   uint32_t stage_{};
+  bool log_request_response_info_{};
 };
 
 class RouteFilterConfig : public Router::RouteSpecificFilterConfig,

--- a/source/extensions/filters/http/transformation/transformer.h
+++ b/source/extensions/filters/http/transformation/transformer.h
@@ -39,6 +39,7 @@ struct TransformationFilterStats {
 
 class Transformer {
 public:
+  Transformer(bool log_request_response_info) : log_request_response_info_(log_request_response_info) {}
   virtual ~Transformer() {}
 
   virtual bool passthrough_body() const PURE;
@@ -49,6 +50,10 @@ public:
                          Http::RequestHeaderMap *request_headers,
                          Buffer::Instance &body,
                          Http::StreamFilterCallbacks &callbacks) const PURE;
+
+  bool logRequestResponseInfo() const { return log_request_response_info_; }
+
+  bool log_request_response_info_{};
 };
 
 typedef std::shared_ptr<const Transformer> TransformerConstSharedPtr;
@@ -58,7 +63,10 @@ public:
   TransformerPair(TransformerConstSharedPtr request_transformer,
                   TransformerConstSharedPtr response_transformer,
                   TransformerConstSharedPtr on_stream_completion_transformer,
-                  bool should_clear_cache);
+                  bool should_clear_cache
+                  );
+                  // ,
+                  // bool log_request_response_info);
 
   TransformerConstSharedPtr getRequestTranformation() const {
     return request_transformation_;
@@ -74,8 +82,11 @@ public:
 
   bool shouldClearCache() const { return clear_route_cache_; }
 
+  // bool logRequestResponseInfo() const { return log_request_response_info_; }
+
 private:
   bool clear_route_cache_{};
+  // bool log_request_response_info_{};
   TransformerConstSharedPtr request_transformation_;
   TransformerConstSharedPtr response_transformation_;
   TransformerConstSharedPtr on_stream_completion_transformation_;


### PR DESCRIPTION
# Description
 - Expand transformation logging so that request/response body and headers are logged before a transformation is executed
   - More work to follow that will add similar functionality after transformations are executed
 - Adds new transformation-level setting to enable this functionality
 - Adds new transformation-filter-level setting to override the transformation-level setting
WIP
