### PR TITLE
Update `create_transformer` signature to facilitate debug logging in enterprise transformations

### DIFF
--- a/changelog/v1.25.6-patch4/transformation_logging_create_transformer_update.yaml
+++ b/changelog/v1.25.6-patch4/transformation_logging_create_transformer_update.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/8266
+  resolvesIssue: false
+  description: >-
+    Addresses a blind spot missed in the original PR (#240)
+    to add additional debug logging to transformations.
+    This change allows transformations defined outside of 
+    envoy-gloo-ee to support that functionality.

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -301,13 +301,13 @@ AWSLambdaRouteConfig::AWSLambdaRouteConfig(
   if (protoconfig.has_transformer_config()) {
     auto &factory = Config::Utility::getAndCheckFactory<Transformation::TransformerExtensionFactory>(protoconfig.transformer_config());
     auto config = Config::Utility::translateAnyToFactoryConfig(protoconfig.transformer_config().typed_config(), context.messageValidationContext().staticValidationVisitor(), factory);
-    transformer_config_ = factory.createTransformer(*config, context);
+    transformer_config_ = factory.createTransformer(*config, google::protobuf::BoolValue(), context);
   }
 
   if (protoconfig.has_request_transformer_config()) {
     auto &request_transformer_factory = Config::Utility::getAndCheckFactory<Transformation::TransformerExtensionFactory>(protoconfig.request_transformer_config());
     auto request_transformer_config = Config::Utility::translateAnyToFactoryConfig(protoconfig.request_transformer_config().typed_config(), context.messageValidationContext().staticValidationVisitor(), request_transformer_factory);
-    request_transformer_config_ = request_transformer_factory.createTransformer(*request_transformer_config, context);
+    request_transformer_config_ = request_transformer_factory.createTransformer(*request_transformer_config, google::protobuf::BoolValue(), context);
   }
 }
 

--- a/source/extensions/filters/http/transformation/transformation_filter_config.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.cc
@@ -29,7 +29,7 @@ TransformerConstSharedPtr Transformation::getTransformer(
   case envoy::api::v2::filter::http::Transformation::kTransformerConfig: {
     auto &factory = Config::Utility::getAndCheckFactory<TransformerExtensionFactory>(transformation.transformer_config());
     auto config = Config::Utility::translateAnyToFactoryConfig(transformation.transformer_config().typed_config(), context.messageValidationContext().staticValidationVisitor(), factory);
-    return factory.createTransformer(*config, context);
+    return factory.createTransformer(*config, transformation.log_request_response_info(), context);
   }
   case envoy::api::v2::filter::http::Transformation::
       TRANSFORMATION_TYPE_NOT_SET:

--- a/source/extensions/filters/http/transformation/transformation_filter_config.h
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.h
@@ -111,6 +111,7 @@ public:
  * @param config the custom configuration for this transformer extension type.
  */
   virtual TransformerConstSharedPtr createTransformer(const Protobuf::Message &config,
+    google::protobuf::BoolValue log_request_response_info,
     Server::Configuration::CommonFactoryContext &context) PURE;
 
   virtual std::string name() const override PURE;

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.cc
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.cc
@@ -18,6 +18,7 @@ namespace AwsLambda {
 HttpFilters::Transformation::TransformerConstSharedPtr
 ApiGatewayTransformerFactory::createTransformer(
     const Protobuf::Message &config,
+    google::protobuf::BoolValue log_request_response_info,
     Server::Configuration::CommonFactoryContext &context) {
     MessageUtil::downcastAndValidate<const ApiGatewayTransformerProto &>(
           config, context.messageValidationContext().staticValidationVisitor());

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.cc
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.cc
@@ -18,7 +18,7 @@ namespace AwsLambda {
 HttpFilters::Transformation::TransformerConstSharedPtr
 ApiGatewayTransformerFactory::createTransformer(
     const Protobuf::Message &config,
-    google::protobuf::BoolValue log_request_response_info,
+    __attribute__((unused)) google::protobuf::BoolValue log_request_response_info,
     Server::Configuration::CommonFactoryContext &context) {
     MessageUtil::downcastAndValidate<const ApiGatewayTransformerProto &>(
           config, context.messageValidationContext().staticValidationVisitor());

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
@@ -29,6 +29,7 @@ class ApiGatewayTransformerFactory
 public:
   HttpFilters::Transformation::TransformerConstSharedPtr createTransformer(
       const Protobuf::Message &config,
+      google::protobuf::BoolValue log_request_response_info,
       Server::Configuration::CommonFactoryContext &context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/test/extensions/filters/http/aws_lambda/test_transformer.h
+++ b/test/extensions/filters/http/aws_lambda/test_transformer.h
@@ -40,7 +40,7 @@ public:
   std::string name() const override {return "io.solo.transformer.api_gateway_test_transformer";}
 
   TransformerConstSharedPtr createTransformer(const Protobuf::Message &,
-  google::protobuf::BoolValue log_request_response_info,
+   __attribute__((unused)) google::protobuf::BoolValue log_request_response_info,
   Server::Configuration::CommonFactoryContext &) override {
     return std::make_shared<FakeTransformer>();
   }

--- a/test/extensions/filters/http/aws_lambda/test_transformer.h
+++ b/test/extensions/filters/http/aws_lambda/test_transformer.h
@@ -40,6 +40,7 @@ public:
   std::string name() const override {return "io.solo.transformer.api_gateway_test_transformer";}
 
   TransformerConstSharedPtr createTransformer(const Protobuf::Message &,
+  google::protobuf::BoolValue log_request_response_info,
   Server::Configuration::CommonFactoryContext &) override {
     return std::make_shared<FakeTransformer>();
   }

--- a/test/extensions/filters/http/transformation/fake_transformer.h
+++ b/test/extensions/filters/http/transformation/fake_transformer.h
@@ -28,7 +28,7 @@ public:
   std::string name() const override {return "io.solo.transformer.fake";}
 
   TransformerConstSharedPtr createTransformer(const Protobuf::Message &,
-  google::protobuf::BoolValue log_request_response_info,
+   __attribute__((unused)) google::protobuf::BoolValue log_request_response_info,
   Server::Configuration::CommonFactoryContext &) override {
     return std::make_shared<FakeTransformer>();
   }

--- a/test/extensions/filters/http/transformation/fake_transformer.h
+++ b/test/extensions/filters/http/transformation/fake_transformer.h
@@ -28,6 +28,7 @@ public:
   std::string name() const override {return "io.solo.transformer.fake";}
 
   TransformerConstSharedPtr createTransformer(const Protobuf::Message &,
+  google::protobuf::BoolValue log_request_response_info,
   Server::Configuration::CommonFactoryContext &) override {
     return std::make_shared<FakeTransformer>();
   }


### PR DESCRIPTION
# Description
 - Addresses a blind spot missed in https://github.com/solo-io/envoy-gloo/pull/240
 - That PR added settings which could be used to enable additional debug logging for transformations processed via the transformation filter. However, it failed to support this feature in transformations not defined in envoy-gloo (i.e., enterprise transformations defined in envoy-gloo-ee)
 - This PR adds support for this functionality in transformations defined outside of this repository.