### PR TITLE
Bump Inja dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(COMMIT_SHA)
+VERSION ?= $(COMMIT_SHA)
 RELEASE := "false"
 ifneq ($(TAGGED_VERSION),)
         VERSION := $(shell echo $(TAGGED_VERSION) | cut -c 2-)

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -5,7 +5,7 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(
-        commit = "4c0ee3a46c0bbb279b0849e5a659e52684a37a98",
+        commit = "5a18986825fc7e5d2916ff345c4369e4b6ea7122", # v3.4 + JSON Pointers
         remote = "https://github.com/pantor/inja",
     ),
     json = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -6,7 +6,7 @@ REPOSITORY_LOCATIONS = dict(
     ),
     inja = dict(
         commit = "5a18986825fc7e5d2916ff345c4369e4b6ea7122", # v3.4 + JSON Pointers
-        remote = "https://github.com/pantor/inja",
+        remote = "https://github.com/solo-io/inja", # solo-io fork including the changes
     ),
     json = dict(
         commit = "bc889afb4c5bf1c0d8ee29ef35eaaf4c8bef8a5d",  # v3.11.2

--- a/changelog/v1.26.2-patch2/inja-bump.yaml
+++ b/changelog/v1.26.2-patch2/inja-bump.yaml
@@ -1,5 +1,7 @@
 changelog:
 - type: DEPENDENCY_BUMP
+  issueLink: https://github.com/solo-io/gloo/issues/8177
+  resolvesIssue: false
   dependencyOwner: pantor
   dependencyRepo: inja
   dependencyTag: 3.4
@@ -7,3 +9,6 @@ changelog:
     Use newer version of Inja templating engine. This upgrade includes numerous
     performance improvements in the template parsing logic as well as access to
     more recent Inja builtin functions.
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/envoy-gloo/issues/247
+  resolvesIssue: false

--- a/changelog/v1.26.2-patch2/inja-bump.yaml
+++ b/changelog/v1.26.2-patch2/inja-bump.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: pantor
+  dependencyRepo: inja
+  dependencyTag: 3.4
+  description: >-
+    Use newer version of Inja templating engine in order to include newer template
+    features, specifically 'set'

--- a/changelog/v1.26.2-patch2/inja-bump.yaml
+++ b/changelog/v1.26.2-patch2/inja-bump.yaml
@@ -4,5 +4,6 @@ changelog:
   dependencyRepo: inja
   dependencyTag: 3.4
   description: >-
-    Use newer version of Inja templating engine in order to include newer template
-    features, specifically 'set'
+    Use newer version of Inja templating engine. This upgrade includes numerous
+    performance improvements in the template parsing logic as well as access to
+    more recent Inja builtin functions.

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -347,7 +347,7 @@ inja::Template TransformerInstance::parse(std::string_view input) {
     return env_.parse(input);
 }
 
-std::string TransformerInstance::render(const inja::Template &input) {
+std::string TransformerInstance::render(const inja::Template &input) const {
   // inja can't handle context that are not objects correctly, so we give it an
   // empty object in that case
   const auto& ctx = tls_.getTyped<ThreadLocalTransformerContext>();
@@ -369,9 +369,9 @@ InjaTransformer::InjaTransformer(const TransformationTemplate &transformation,
       parse_body_behavior_(transformation.parse_body_behavior()),
       ignore_error_on_parse_(transformation.ignore_error_on_parse()),
       tls_(tls.allocateSlot()),
-      instance_(std::make_unique<TransformerInstance>(*tls_, rng)) {
+      instance_(TransformerInstance(*tls_, rng)) {
   if (advanced_templates_) {
-    instance_->set_element_notation(inja::ElementNotation::Pointer);
+    instance_.set_element_notation(inja::ElementNotation::Pointer);
   }
 
   tls_->set([](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
@@ -387,7 +387,7 @@ InjaTransformer::InjaTransformer(const TransformationTemplate &transformation,
     Http::LowerCaseString header_name(it->first);
     try {
       headers_.emplace_back(std::make_pair(std::move(header_name),
-                                           instance_->parse(it->second.text())));
+                                           instance_.parse(it->second.text())));
     } catch (const std::exception &e) {
       throw EnvoyException(fmt::format(
           "Failed to parse header template '{}': {}", it->first, e.what()));
@@ -409,7 +409,7 @@ InjaTransformer::InjaTransformer(const TransformationTemplate &transformation,
     Http::LowerCaseString header_name(it.key());
     try {
       headers_to_append_.emplace_back(std::make_pair(std::move(header_name),
-                                           instance_->parse(it.value().text())));
+                                           instance_.parse(it.value().text())));
     } catch (const std::exception &e) {
       throw EnvoyException(fmt::format(
           "Failed to parse header template '{}': {}", it.key(), e.what()));
@@ -427,7 +427,7 @@ InjaTransformer::InjaTransformer(const TransformationTemplate &transformation,
             SoloHttpFilterNames::get().Transformation;
       }
       dynamicMetadataValue.key_ = it->key();
-      dynamicMetadataValue.template_ = instance_->parse(it->value().text());
+      dynamicMetadataValue.template_ = instance_.parse(it->value().text());
       dynamic_metadata_.emplace_back(std::move(dynamicMetadataValue));
     } catch (const std::exception &e) {
       throw EnvoyException(fmt::format(
@@ -438,7 +438,7 @@ InjaTransformer::InjaTransformer(const TransformationTemplate &transformation,
   switch (transformation.body_transformation_case()) {
   case TransformationTemplate::kBody: {
     try {
-      body_template_.emplace(instance_->parse(transformation.body().text()));
+      body_template_.emplace(instance_.parse(transformation.body().text()));
     } catch (const std::exception &e) {
       throw EnvoyException(
           fmt::format("Failed to parse body template {}", e.what()));
@@ -552,7 +552,7 @@ void InjaTransformer::transform(Http::RequestOrResponseHeaderMap &header_map,
   absl::optional<Buffer::OwnedImpl> maybe_body;
 
   if (body_template_.has_value()) {
-    std::string output = instance_->render(body_template_.value());
+    std::string output = instance_.render(body_template_.value());
     maybe_body.emplace(output);
   } else if (merged_extractors_to_body_) {
     std::string output = json_body.dump();
@@ -561,7 +561,7 @@ void InjaTransformer::transform(Http::RequestOrResponseHeaderMap &header_map,
 
   // DynamicMetadata transform:
   for (const auto &templated_dynamic_metadata : dynamic_metadata_) {
-    std::string output = instance_->render(templated_dynamic_metadata.template_);
+    std::string output = instance_.render(templated_dynamic_metadata.template_);
     if (!output.empty()) {
       ProtobufWkt::Struct strct(
           MessageUtil::keyValueStruct(templated_dynamic_metadata.key_, output));
@@ -572,7 +572,7 @@ void InjaTransformer::transform(Http::RequestOrResponseHeaderMap &header_map,
 
   // Headers transform:
   for (const auto &templated_header : headers_) {
-    std::string output = instance_->render(templated_header.second);
+    std::string output = instance_.render(templated_header.second);
     // remove existing header
     header_map.remove(templated_header.first);
     // TODO(yuval-k): Do we need to support intentional empty headers?
@@ -589,7 +589,7 @@ void InjaTransformer::transform(Http::RequestOrResponseHeaderMap &header_map,
 
   // Headers to Append Values transform:
   for (const auto &templated_header : headers_to_append_) {
-    std::string output = instance_->render(templated_header.second);
+    std::string output = instance_.render(templated_header.second);
     if (!output.empty()) {
       // we can add the key as reference as the headers_to_append_ lifetime is as the
       // route's

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -104,8 +104,10 @@ Extractor::extractValue(Http::StreamFilterCallbacks &callbacks,
   return "";
 }
 
-// A TransformerInstance is constructed by the InjaTransformer::transform method
-// on the request path, and may be executed on any worker thread
+// A TransformerInstance is constructed by the InjaTransformer constructor at config time
+// on the main thread. It access thread-local storage which is populated during the
+// InjaTransformer::transform method call, which happens on the request path on any
+// given worker thread.
 TransformerInstance::TransformerInstance(ThreadLocal::Slot &tls, Envoy::Random::RandomGenerator &rng)
     : tls_(tls), rng_(rng) {
   env_.add_callback("header", 1,

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -43,7 +43,7 @@ public:
   TransformerInstance(ThreadLocal::Slot& tls, Envoy::Random::RandomGenerator &rng);
 
   inja::Template parse(std::string_view input);
-  std::string render(const inja::Template &input) const;
+  std::string render(const inja::Template &input);
   void set_element_notation(inja::ElementNotation notation) {
       env_.set_element_notation(notation);
   };
@@ -123,7 +123,7 @@ private:
   absl::optional<inja::Template> body_template_;
   bool merged_extractors_to_body_{};
   ThreadLocal::SlotPtr tls_;
-  TransformerInstance instance_;
+  std::unique_ptr<TransformerInstance> instance_;
 };
 
 } // namespace Transformation

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -43,7 +43,7 @@ public:
   TransformerInstance(ThreadLocal::Slot& tls, Envoy::Random::RandomGenerator &rng);
 
   inja::Template parse(std::string_view input);
-  std::string render(const inja::Template &input);
+  std::string render(const inja::Template &input) const;
   void set_element_notation(inja::ElementNotation notation) {
       env_.set_element_notation(notation);
   };
@@ -123,7 +123,7 @@ private:
   absl::optional<inja::Template> body_template_;
   bool merged_extractors_to_body_{};
   ThreadLocal::SlotPtr tls_;
-  std::unique_ptr<TransformerInstance> instance_;
+  TransformerInstance instance_;
 };
 
 } // namespace Transformation

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -24,18 +24,38 @@ namespace Transformation {
 
 using GetBodyFunc = std::function<const std::string &()>;
 
-class TransformerInstance {
+struct ThreadLocalTransformerRequestData : public ThreadLocal::ThreadLocalObject {
 public:
-  TransformerInstance(
+
+  ThreadLocalTransformerRequestData(
       const Http::RequestOrResponseHeaderMap &header_map,
-      const Http::RequestHeaderMap *request_headers, GetBodyFunc &body,
+      const Http::RequestHeaderMap *request_headers, const GetBodyFunc &body,
       const std::unordered_map<std::string, absl::string_view> &extractions,
       const nlohmann::json &context,
       const std::unordered_map<std::string, std::string> &environ,
       const envoy::config::core::v3::Metadata *cluster_metadata,
       Envoy::Random::RandomGenerator &rng);
 
+  const Http::RequestOrResponseHeaderMap &header_map_;
+  const Http::RequestHeaderMap *request_headers_;
+  const GetBodyFunc &body_;
+  const std::unordered_map<std::string, absl::string_view> &extractions_;
+  const nlohmann::json &context_;
+  const std::unordered_map<std::string, std::string> &environ_;
+  const envoy::config::core::v3::Metadata *cluster_metadata_;
+  Envoy::Random::RandomGenerator &rng_;
+};
+
+
+class TransformerInstance {
+public:
+  TransformerInstance(ThreadLocal::Slot& tls);
+
+  inja::Template parse(std::string_view input);
   std::string render(const inja::Template &input);
+  void set_element_notation(inja::ElementNotation notation) {
+      env_.set_element_notation(notation);
+  };
 
 private:
   // header_value(name)
@@ -53,15 +73,8 @@ private:
   std::string& random_for_pattern(const std::string& pattern);
 
   inja::Environment env_;
-  const Http::RequestOrResponseHeaderMap &header_map_;
-  const Http::RequestHeaderMap *request_headers_;
-  GetBodyFunc &body_;
-  const std::unordered_map<std::string, absl::string_view> &extractions_;
-  const nlohmann::json &context_;
-  const std::unordered_map<std::string, std::string> &environ_;
-  const envoy::config::core::v3::Metadata *cluster_metadata_;
   absl::flat_hash_map<std::string, std::string> pattern_replacements_;
-  Envoy::Random::RandomGenerator &rng_;
+  ThreadLocal::Slot &tls_;
 };
 
 class Extractor : Logger::Loggable<Logger::Id::filter> {
@@ -83,8 +96,10 @@ private:
 
 class InjaTransformer : public Transformer {
 public:
-  InjaTransformer(const envoy::api::v2::filter::http::TransformationTemplate
-                      &transformation, Envoy::Random::RandomGenerator &rng, google::protobuf::BoolValue log_request_response_info);
+  InjaTransformer(const envoy::api::v2::filter::http::TransformationTemplate &transformation,
+                  Envoy::Random::RandomGenerator &rng,
+                  google::protobuf::BoolValue log_request_response_info,
+                  ThreadLocal::SlotAllocator &tls_);
   ~InjaTransformer();
 
   void transform(Http::RequestOrResponseHeaderMap &map,
@@ -116,6 +131,8 @@ private:
   absl::optional<inja::Template> body_template_;
   bool merged_extractors_to_body_{};
   Envoy::Random::RandomGenerator &rng_;
+  ThreadLocal::SlotPtr tls_;
+  std::unique_ptr<TransformerInstance> instance_;
 };
 
 } // namespace Transformation

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -26,19 +26,6 @@ using GetBodyFunc = std::function<const std::string &()>;
 
 struct ThreadLocalTransformerContext : public ThreadLocal::ThreadLocalObject {
 public:
-
-  ThreadLocalTransformerContext(
-      Http::RequestOrResponseHeaderMap *header_map,
-      Http::RequestHeaderMap *request_headers,
-      GetBodyFunc *body,
-      std::unordered_map<std::string, absl::string_view> *extractions,
-      nlohmann::json *context,
-      std::unordered_map<std::string, std::string> *environ,
-      envoy::config::core::v3::Metadata *cluster_metadata)
-      : header_map_(header_map), request_headers_(request_headers), body_(body),
-      extractions_(extractions), context_(context), environ_(environ),
-      cluster_metadata_(cluster_metadata) {}
-
   ThreadLocalTransformerContext(){}
 
   const Http::RequestOrResponseHeaderMap *header_map_;

--- a/source/extensions/filters/http/transformation/transformation_filter_config.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.cc
@@ -21,7 +21,7 @@ TransformerConstSharedPtr Transformation::getTransformer(
   switch (transformation.transformation_type_case()) {
   case envoy::api::v2::filter::http::Transformation::kTransformationTemplate:
     return std::make_unique<InjaTransformer>(
-        transformation.transformation_template(), context.api().randomGenerator(), transformation.log_request_response_info());
+        transformation.transformation_template(), context.api().randomGenerator(), transformation.log_request_response_info(), context.threadLocal());
   case envoy::api::v2::filter::http::Transformation::kHeaderBodyTransform: {
     const auto& header_body_transform = transformation.header_body_transform();
     return std::make_unique<BodyHeaderTransformer>(header_body_transform.add_request_metadata(), transformation.log_request_response_info());

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -381,7 +381,7 @@ TEST_F(TransformerTest, transformHeaderAndHeadersToAppend) {
   // this should overwrite existing headers with the same name
   (*transformation.mutable_headers())["x-custom-header"].set_text(
       "{{upper(\"overwritten value\")}}");
-  // define "headers_to_append" 
+  // define "headers_to_append"
   // these header values should be appended to the current x-custom-header
   const auto &header = transformation.add_headers_to_append();
   header->set_key("x-custom-header");
@@ -1041,7 +1041,7 @@ TEST_F(InjaTransformerTest, ReplaceWithRandomTest_SameReplacementPatternUsesSame
 {{{{ replace_with_random("{}", "{}") }}}}
   )ENDFMT";
 
-  auto formatted_string = fmt::format(format_string, 
+  auto formatted_string = fmt::format(format_string,
     test_string1, pattern1,
     test_string2, pattern2,
     test_string3, pattern3,
@@ -1062,6 +1062,20 @@ TEST_F(InjaTransformerTest, ReplaceWithRandomTest_SameReplacementPatternUsesSame
   assert_replacements(body.toString(), "test-1-");
   assert_replacements(body.toString(), "test-2-");
   assert_replacements(body.toString(), "test-3-");
+}
+
+TEST_F(InjaTransformerTest, ParseUsingSetKeyword) {
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
+  TransformationTemplate transformation;
+  transformation.mutable_body()->set_text(
+      "{% set foo = \"bar\" %}{{ foo }}");
+  InjaTransformer transformer(transformation, rng_, google::protobuf::BoolValue());
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+
+  Buffer::OwnedImpl body("{\"bat\":\"baz\"}");
+  transformer.transform(headers, &headers, body, callbacks);
+  EXPECT_EQ(body.toString(), "bar");
 }
 
 } // namespace Transformation


### PR DESCRIPTION
Uses thread-local storage to pass request data into the `TransformerInstance` so that we can use the instance (and its registered callbacks) to parse templates at init time.