### PR TITLE
Health checkers as extensions

### DIFF
--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -62,6 +62,9 @@ EXTENSIONS = {
     #
 
     "envoy.health_checkers.redis":                      "//source/extensions/health_checkers/redis:config",
+    "envoy.health_checkers.tcp":                        "//source/extensions/health_checkers/tcp:health_checker_lib",
+    "envoy.health_checkers.http":                       "//source/extensions/health_checkers/http:health_checker_lib",
+    "envoy.health_checkers.grpc":                       "//source/extensions/health_checkers/grpc:health_checker_lib",
 
     #
     # Input Matchers

--- a/changelog/v1.26.2-patch3/extensions-health-checkers.yaml
+++ b/changelog/v1.26.2-patch3/extensions-health-checkers.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Upstream moved health checkers out of common code and into extensions. In
+    order to use these health checkers, we have to modify our extensions_build_config.


### PR DESCRIPTION
## Description
Accommodate the upstream changes made in [this PR](https://github.com/envoyproxy/envoy/pull/26266) by updating our `extensions_build_config` to include the new health checkers extensions. These were previously in common code.

## Context
Released version v1.26.2-patch2 was failing build bot tests in a [gloo PR](https://github.com/solo-io/gloo/pull/8440). The kube2e tests were all passing with this version, but just the health checker tests in build bot were failing with Didn't find a registered implementation for name: `'envoy.health_checkers.tcp'`. Discovered these moved in [this upstream PR](https://github.com/envoyproxy/envoy/pull/26266). After making the changes, the tests that were failing are now passing in Gloo. Now some kube2e tests are failing but that's just due to the hoops I had to jump through to test an unreleased envoy-gloo.