### PR TITLE
ci updates to unspool our 1.26 changes for 1.25 ci 

### DIFF
--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -1,3 +1,7 @@
+# CHECK_ON_MINOR_UPDATE we dont need to register everything nessecarily 
+# but we must register all extensions we may use
+
+
 # See bazel/README.md for details on how this system works.
 MOBILE_PACKAGE_VISIBILITY = ["@envoy//:mobile_library"]
 EXTENSIONS = {

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,17 +1,73 @@
-# This file was inspired by envoy Dockerfile:
-# https://github.com/envoyproxy/envoy/blob/445a67344ffda0c8828c8e438e463fcaa7878434/ci/Dockerfile-envoy-alpine
+# Inspired by https://github.com/envoyproxy/envoy/blob/25684687e64d47dd0c865b88d37432141770e5c7/ci/Dockerfile-envoy
+# Last updated with 1.26.3
+# CHECK_ON_MINOR_UPDATE do not take upstream as is, cut down to only builds we need
 
-FROM frolvlad/alpine-glibc:alpine-3.17_glibc-2.34
+ARG BUILD_OS=ubuntu
+ARG BUILD_TAG=20.04
+ARG ENVOY_VRP_BASE_IMAGE=envoy-base
 
-ENV loglevel=info
 
-RUN apk upgrade --update-cache \
-    && apk add dumb-init ca-certificates \
-    && rm -rf /var/cache/apk/*
+FROM scratch AS binary
+# this matters for envoy-gloo but is overwritten in gloo
+# so we mimick this file between the repos for now
+COPY ci/docker-entrypoint.sh /
 
-RUN mkdir -p /etc/envoy
 
-ADD envoy.stripped /usr/local/bin/envoy
+# See https://github.com/docker/buildx/issues/510 for why this _must_ be this way
+ARG TARGETPLATFORM
+ENV TARGETPLATFORM="${TARGETPLATFORM:-linux/amd64}"
+ADD "${TARGETPLATFORM}/release.tar.zst" /usr/local/bin/
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/bin/envoy"]
+
+# STAGE: envoy-base
+FROM ${BUILD_OS}:${BUILD_TAG} AS envoy-base
+ENV DEBIAN_FRONTEND=noninteractive
+EXPOSE 10000
+CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
+RUN mkdir -p /etc/envoy \
+    && adduser --group --system envoy
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/docker-entrypoint.sh"]
+# NB: Adding this here means that following steps, for example updating the system packages, are run
+#   when the version file changes. This should mean that a release version will always update.
+#   In PRs this will just use cached layers unless either this file changes or the version has changed.
+ADD VERSION.txt /etc/envoy
+RUN --mount=type=tmpfs,target=/var/cache/apt \
+    --mount=type=tmpfs,target=/var/lib/apt/lists \
+    apt-get -qq update \
+    && apt-get -qq upgrade -y \
+    && apt-get -qq install --no-install-recommends -y ca-certificates \
+    && apt-get -qq autoremove -y
+
+
+# STAGE: envoy
+FROM envoy-base AS envoy
+COPY --from=binary --chown=0:0 --chmod=644 \
+    /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
+COPY --from=binary --chown=0:0 --chmod=755 \
+    /docker-entrypoint.sh /
+COPY --from=binary --chown=0:0 --chmod=755 \
+    /usr/local/bin/utils/su-exec /usr/local/bin/
+ARG ENVOY_BINARY=envoy
+ARG ENVOY_BINARY_PREFIX=
+COPY --from=binary --chown=0:0 --chmod=755 \
+    "/usr/local/bin/${ENVOY_BINARY_PREFIX}${ENVOY_BINARY}" /usr/local/bin/envoy
+COPY --from=binary --chown=0:0 --chmod=755 \
+    /usr/local/bin/${ENVOY_BINARY_PREFIX}${ENVOY_BINARY}\.* /usr/local/bin/
+
+
+# TODO: Do we need this stage (probably not)
+
+# STAGE: envoy-distroless
+# gcr.io/distroless/base-nossl-debian11:nonroot
+FROM gcr.io/distroless/base-nossl-debian11:nonroot@sha256:f10e1fbf558c630a4b74a987e6c754d45bf59f9ddcefce090f6b111925996767 AS envoy-distroless
+EXPOSE 10000
+ENTRYPOINT ["/usr/local/bin/envoy"]
 CMD ["-c", "/etc/envoy/envoy.yaml"]
+COPY --from=binary --chown=0:0 --chmod=644 \
+    /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
+COPY --from=binary --chown=0:0 --chmod=755 \
+    /usr/local/bin/envoy /usr/local/bin/
+
+
+# Make envoy image as last stage so it is built by default
+FROM envoy

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -9,13 +9,14 @@ ARG BUILD_TAG=20.04
 FROM scratch AS binary
 # this matters for envoy-gloo but is overwritten in gloo
 # so we mimick this file between the repos for now
-COPY docker-entrypoint.sh /
+COPY ci/docker-entrypoint.sh /
 
 
 # See https://github.com/docker/buildx/issues/510 for why this _must_ be this way
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM="${TARGETPLATFORM:-linux/amd64}"
-ADD "${TARGETPLATFORM}/release.tar.zst" /usr/local/bin/
+# ADD "${TARGETPLATFORM}/release.tar.zst" /usr/local/bin/
+ADD envoy.stripped /usr/local/bin/envoy
 
 
 # STAGE: envoy-base
@@ -23,8 +24,8 @@ FROM ${BUILD_OS}:${BUILD_TAG} AS envoy-base
 ENV DEBIAN_FRONTEND=noninteractive
 EXPOSE 10000
 CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
-RUN mkdir -p /etc/envoy \
-    && adduser --group --system envoy
+RUN mkdir -p /etc/envoy 
+#   && adduser --group --system envoy # for now we can hardcode like we did previously
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/docker-entrypoint.sh"]
 # NB: Adding this here means that following steps, for example updating the system packages, are run
 #   when the version file changes. This should mean that a release version will always update.

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILD_TAG=20.04
 FROM scratch AS binary
 # this matters for envoy-gloo but is overwritten in gloo
 # so we mimick this file between the repos for now
-COPY ci/docker-entrypoint.sh /
+COPY docker-entrypoint.sh /
 
 
 # See https://github.com/docker/buildx/issues/510 for why this _must_ be this way
@@ -27,10 +27,8 @@ CMD ["envoy", "-c", "/etc/envoy/envoy.yaml"]
 RUN mkdir -p /etc/envoy 
 #   && adduser --group --system envoy # for now we can hardcode like we did previously
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/docker-entrypoint.sh"]
-# NB: Adding this here means that following steps, for example updating the system packages, are run
-#   when the version file changes. This should mean that a release version will always update.
-#   In PRs this will just use cached layers unless either this file changes or the version has changed.
-ADD VERSION.txt /etc/envoy
+
+
 RUN --mount=type=tmpfs,target=/var/cache/apt \
     --mount=type=tmpfs,target=/var/lib/apt/lists \
     apt-get -qq update \
@@ -41,8 +39,8 @@ RUN --mount=type=tmpfs,target=/var/cache/apt \
 
 # STAGE: envoy
 FROM envoy-base AS envoy
-COPY --from=binary --chown=0:0 --chmod=644 \
-    /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
+# COPY --from=binary --chown=0:0 --chmod=644 \
+#     /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
 COPY --from=binary --chown=0:0 --chmod=755 \
     /docker-entrypoint.sh /
 COPY --from=binary --chown=0:0 --chmod=755 \
@@ -54,19 +52,6 @@ COPY --from=binary --chown=0:0 --chmod=755 \
 COPY --from=binary --chown=0:0 --chmod=755 \
     /usr/local/bin/${ENVOY_BINARY_PREFIX}${ENVOY_BINARY}\.* /usr/local/bin/
 
-
-# TODO: Do we need this stage (probably not)
-
-# STAGE: envoy-distroless
-# gcr.io/distroless/base-nossl-debian11:nonroot
-FROM gcr.io/distroless/base-nossl-debian11:nonroot@sha256:f10e1fbf558c630a4b74a987e6c754d45bf59f9ddcefce090f6b111925996767 AS envoy-distroless
-EXPOSE 10000
-ENTRYPOINT ["/usr/local/bin/envoy"]
-CMD ["-c", "/etc/envoy/envoy.yaml"]
-COPY --from=binary --chown=0:0 --chmod=644 \
-    /etc/envoy/envoy.yaml /etc/envoy/envoy.yaml
-COPY --from=binary --chown=0:0 --chmod=755 \
-    /usr/local/bin/envoy /usr/local/bin/
 
 
 # Make envoy image as last stage so it is built by default

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILD_TAG=20.04
 FROM scratch AS binary
 # this matters for envoy-gloo but is overwritten in gloo
 # so we mimick this file between the repos for now
-COPY ci/docker-entrypoint.sh /
+COPY docker-entrypoint.sh /
 
 
 # See https://github.com/docker/buildx/issues/510 for why this _must_ be this way

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,7 +4,6 @@
 
 ARG BUILD_OS=ubuntu
 ARG BUILD_TAG=20.04
-ARG ENVOY_VRP_BASE_IMAGE=envoy-base
 
 
 FROM scratch AS binary

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 set -e
+
+
+# CHECK_ON_MINOR_UPDATE this may be massively affected by non-release note changes
+# make sure to check the do_ci script and any seds that exist in this file
+
 bazel fetch //source/exe:envoy-static
 
 SOURCE_DIR="$(bazel info workspace)"

--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# CHECK_ON_MINOR_UPDATE we dont mimick upstream that close as we have smaller scope 
+# of what we support but we should still check on an upgrade
+# note that in gloo we overwrite this anyways
+
+if "${DISABLE_CORE_DUMPS:-false}" ; then
+  ulimit -c 0
+fi
+
+exec /usr/local/bin/envoyinit "$@"
+


### PR DESCRIPTION
First start with docker file changes for https://github.com/envoyproxy/envoy/commit/5e3671daed36e4afcfd366b02241269d7b4e4251 


Then we also have to deal with the change from tar-> tar.zst (start using bazel for more build) 
 https://github.com/envoyproxy/envoy/commit/d4f3bf2f02d97b4a9ab6dd1fee2652bb8e7f9137#diff-f8dc7806438a32216515d736fe82b608eea44bdb8aa1d00c6e17fccba74c4495