### PR TITLE
Inja transformation preserve escaped json

### DIFF
--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -257,7 +257,7 @@ message TransformationTemplate {
   repeated DynamicMetadataValue dynamic_metadata_values = 9;
 
   // Use to render the output of a body transformation as JSON. This will cause
-  // rendered values to be escaped in order to make valid JSON strings
+  // rendered string values to be escaped in order to make valid JSON strings
   bool render_body_as_json = 12;
 
 }

--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -256,9 +256,9 @@ message TransformationTemplate {
   // Use this field to set Dynamic Metadata.
   repeated DynamicMetadataValue dynamic_metadata_values = 9;
 
-  // Use to render the output of a body transformation as JSON. This will cause
-  // rendered string values to be escaped in order to make valid JSON strings
-  bool render_body_as_json = 12;
+  // Use to escape the output of a body transformation. This will cause
+  // rendered string values to be escaped in order to make valid JSON/YAML strings
+  bool escape_characters = 12;
 
 }
 

--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -204,9 +204,9 @@ message TransformationTemplate {
     InjaTemplate value = 2;
   }
 
-  // Use this attribute to transform request/response headers. It consists of 
-  // an array of string/template objects. Use this attribute to define multiple 
-  // templates for a single header. Header template(s) defined here will be appended to any 
+  // Use this attribute to transform request/response headers. It consists of
+  // an array of string/template objects. Use this attribute to define multiple
+  // templates for a single header. Header template(s) defined here will be appended to any
   // existing headers with the same header name, not replace existing ones.
   repeated HeaderToAppend headers_to_append = 10;
 
@@ -255,6 +255,11 @@ message TransformationTemplate {
   }
   // Use this field to set Dynamic Metadata.
   repeated DynamicMetadataValue dynamic_metadata_values = 9;
+
+  // Use to render the output of a body transformation as JSON. This will cause
+  // rendered values to be escaped in order to make valid JSON strings
+  bool render_body_as_json = 12;
+
 }
 
 // Defines an [Inja template](https://github.com/pantor/inja) that will be

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -5,7 +5,10 @@ REPOSITORY_LOCATIONS = dict(
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(
-        commit = "5a18986825fc7e5d2916ff345c4369e4b6ea7122", # v3.4 + JSON Pointers
+        # Includes unmerged modifications for
+        # - JSON pointer syntax support
+        # - Allowing escaped strings
+        commit = "3aa95b8b58a525f86f79cb547bf937176c9cc7ff", # v3.4.0-patch1
         remote = "https://github.com/solo-io/inja", # solo-io fork including the changes
     ),
     json = dict(

--- a/changelog/v1.26.3-patch2/inja-escaped-body.yaml
+++ b/changelog/v1.26.3-patch2/inja-escaped-body.yaml
@@ -1,0 +1,11 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: inja
+  dependencyTag: v3.4.0-patch2 # not yet released DO NOT MERGE
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/solo-projects/issues/5155
+  resolvesIssue: false
+  description: >-
+    Inja callback `raw_string` added to permit fine-grained escaping of input strings.
+    Also, configuration added to escape all strings for a given transformation.

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -606,6 +606,16 @@ void InjaTransformer::transform(Http::RequestOrResponseHeaderMap &header_map,
   // replace body. we do it here so that headers and dynamic metadata have the
   // original body.
   if (maybe_body.has_value()) {
+    json body_json;
+    if (render_body_as_json_) {
+      try {
+      body_json = json(maybe_body.value().toString());
+      } catch (json::parse_error parse_exception) {
+        ENVOY_STREAM_LOG(debug, "unable to parse body as json; returning as raw {}", callbacks, maybe_body.value().toString());
+      }
+      maybe_body.emplace(body_json.dump());
+    }
+
     // remove content length, as we have new body.
     header_map.removeContentLength();
     // replace body

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -347,18 +347,16 @@ std::string& TransformerInstance::random_for_pattern(const std::string& pattern)
 }
 
 json TransformerInstance::raw_string_callback(const inja::Arguments &args) const {
-  const std::string &input = args.at(0)->get_ref<const std::string &>();
-
-  // in order to get the escaping the way we want, we must cast directly to a json object
-  // since using parse will cause the surrounding " to be stripped
-  auto j = json(input);
+  // inja::Arguments is a std::vector<const json *>, so we can get the json
+  // value from the args directly.
+  const auto& input = args.at(0);
 
   // make sure to bail if we're not working with a raw string value
-  if(!j.is_string()) {
-      return input;
+  if(!input->is_string()) {
+      return input->get_ref<const std::string&>();
   }
 
-  auto val = j.dump();
+  auto val = input->dump();
 
   // This block makes it such that a template must have surrounding " characters
   // around the raw string. This is reasonable since we expect the value we get out of the

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -65,7 +65,7 @@ private:
   nlohmann::json substring_callback(const inja::Arguments &args) const;
   nlohmann::json replace_with_random_callback(const inja::Arguments &args);
   std::string& random_for_pattern(const std::string& pattern);
-  nlohmann::json tojson_callback(const inja::Arguments &args) const;
+  nlohmann::json raw_string_callback(const inja::Arguments &args) const;
 
   inja::Environment env_;
   absl::flat_hash_map<std::string, std::string> pattern_replacements_;
@@ -90,7 +90,7 @@ private:
   const std::regex extract_regex_;
 };
 
-class InjaTransformer : public Transformer, Logger::Loggable<Logger::Id::filter> {
+class InjaTransformer : public Transformer {
 public:
   InjaTransformer(const envoy::api::v2::filter::http::TransformationTemplate &transformation,
                   Envoy::Random::RandomGenerator &rng,

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -65,6 +65,7 @@ private:
   nlohmann::json substring_callback(const inja::Arguments &args) const;
   nlohmann::json replace_with_random_callback(const inja::Arguments &args);
   std::string& random_for_pattern(const std::string& pattern);
+  nlohmann::json tojson_callback(const inja::Arguments &args) const;
 
   inja::Environment env_;
   absl::flat_hash_map<std::string, std::string> pattern_replacements_;

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -47,6 +47,9 @@ public:
   void set_element_notation(inja::ElementNotation notation) {
       env_.set_element_notation(notation);
   };
+  void set_escape_strings(bool escape_strings) {
+      env_.set_escape_strings(escape_strings);
+  };
 
 private:
   // header_value(name)
@@ -62,6 +65,7 @@ private:
   nlohmann::json substring_callback(const inja::Arguments &args) const;
   nlohmann::json replace_with_random_callback(const inja::Arguments &args);
   std::string& random_for_pattern(const std::string& pattern);
+  nlohmann::json json_escaped_callback(const inja::Arguments &args) const;
 
   inja::Environment env_;
   absl::flat_hash_map<std::string, std::string> pattern_replacements_;
@@ -115,11 +119,11 @@ private:
   std::vector<Http::LowerCaseString> headers_to_remove_;
   std::vector<DynamicMetadataValue> dynamic_metadata_;
   std::unordered_map<std::string, std::string> environ_;
-  bool render_body_as_json_{};
 
   envoy::api::v2::filter::http::TransformationTemplate::RequestBodyParse
       parse_body_behavior_;
   bool ignore_error_on_parse_;
+  bool render_body_as_json_{};
 
   absl::optional<inja::Template> body_template_;
   bool merged_extractors_to_body_{};

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -86,7 +86,7 @@ private:
   const std::regex extract_regex_;
 };
 
-class InjaTransformer : public Transformer {
+class InjaTransformer : public Transformer, Logger::Loggable<Logger::Id::filter> {
 public:
   InjaTransformer(const envoy::api::v2::filter::http::TransformationTemplate &transformation,
                   Envoy::Random::RandomGenerator &rng,
@@ -115,6 +115,7 @@ private:
   std::vector<Http::LowerCaseString> headers_to_remove_;
   std::vector<DynamicMetadataValue> dynamic_metadata_;
   std::unordered_map<std::string, std::string> environ_;
+  bool render_body_as_json_{};
 
   envoy::api::v2::filter::http::TransformationTemplate::RequestBodyParse
       parse_body_behavior_;

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -47,6 +47,7 @@ public:
   void set_element_notation(inja::ElementNotation notation) {
       env_.set_element_notation(notation);
   };
+  // Sets the config for rendering strings raw or unescaped
   void set_escape_strings(bool escape_strings) {
       env_.set_escape_strings(escape_strings);
   };
@@ -123,7 +124,7 @@ private:
   envoy::api::v2::filter::http::TransformationTemplate::RequestBodyParse
       parse_body_behavior_;
   bool ignore_error_on_parse_;
-  bool render_body_as_json_{};
+  bool escape_characters_{};
 
   absl::optional<inja::Template> body_template_;
   bool merged_extractors_to_body_{};

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -65,7 +65,6 @@ private:
   nlohmann::json substring_callback(const inja::Arguments &args) const;
   nlohmann::json replace_with_random_callback(const inja::Arguments &args);
   std::string& random_for_pattern(const std::string& pattern);
-  nlohmann::json json_escaped_callback(const inja::Arguments &args) const;
 
   inja::Environment env_;
   absl::flat_hash_map<std::string, std::string> pattern_replacements_;

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -1147,6 +1147,21 @@ TEST_F(InjaTransformerTest, ParseUsingJsonPointerSyntax) {
   EXPECT_EQ(body.toString(), "online--slash--tilde");
 }
 
+TEST_F(InjaTransformerTest, RenderBodyAsJson) {
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
+  TransformationTemplate transformation;
+  transformation.mutable_body()->set_text(
+      "{\"Value\":\"{{ value }}\"}");
+  InjaTransformer transformer(transformation, rng_, google::protobuf::BoolValue(), tls_);
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+
+  Buffer::OwnedImpl body("{\"value\":\"foo\"}");
+  transformer.transform(headers, &headers, body, callbacks);
+  EXPECT_EQ(body.toString(), "{\\\"Value\\\":\\\"foo\\\"}");
+}
+
+
 } // namespace Transformation
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -1147,12 +1147,12 @@ TEST_F(InjaTransformerTest, ParseUsingJsonPointerSyntax) {
   EXPECT_EQ(body.toString(), "online--slash--tilde");
 }
 
-TEST_F(InjaTransformerTest, RenderBodyAsJson) {
+TEST_F(InjaTransformerTest, EscapeCharacters) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
   TransformationTemplate transformation;
   transformation.mutable_body()->set_text(
       R"EOF({"Value":"{{ value }}"})EOF");
-  transformation.set_render_body_as_json(true);
+  transformation.set_escape_characters(true);
   InjaTransformer transformer(transformation, rng_, google::protobuf::BoolValue(), tls_);
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
@@ -1163,12 +1163,28 @@ TEST_F(InjaTransformerTest, RenderBodyAsJson) {
   EXPECT_EQ(body.toString(), expected_body);
 }
 
-TEST_F(InjaTransformerTest, RenderBodyAsJsonDoubleEscapedInput) {
+TEST_F(InjaTransformerTest, EscapeCharactersNestedJson) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
   TransformationTemplate transformation;
   transformation.mutable_body()->set_text(
       R"EOF({"Value":"{{ value }}"})EOF");
-  transformation.set_render_body_as_json(false);
+  transformation.set_escape_characters(true);
+  InjaTransformer transformer(transformation, rng_, google::protobuf::BoolValue(), tls_);
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+
+  Buffer::OwnedImpl body(R"({"value":"{\"foo\":{\"bar\":\"\\\"baz\\\"\"}}"})"_json.dump());
+  auto expected_body = R"({"Value":"{\"foo\":{\"bar\":\"\\\"baz\\\"\"}}"})"_json.dump();
+  transformer.transform(headers, &headers, body, callbacks);
+  EXPECT_EQ(body.toString(), expected_body);
+}
+
+TEST_F(InjaTransformerTest, EscapeCharactersDoubleEscapedInput) {
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
+  TransformationTemplate transformation;
+  transformation.mutable_body()->set_text(
+      R"EOF({"Value":"{{ value }}"})EOF");
+  transformation.set_escape_characters(false);
   InjaTransformer transformer(transformation, rng_, google::protobuf::BoolValue(), tls_);
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
@@ -1184,7 +1200,7 @@ TEST_F(InjaTransformerTest, RawStringCallback) {
   TransformationTemplate transformation;
   transformation.mutable_body()->set_text(
       R"EOF({"Value":"{{ raw_string(value) }}"})EOF");
-  transformation.set_render_body_as_json(false);
+  transformation.set_escape_characters(false);
   InjaTransformer transformer(transformation, rng_, google::protobuf::BoolValue(), tls_);
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
@@ -1195,12 +1211,27 @@ TEST_F(InjaTransformerTest, RawStringCallback) {
   EXPECT_EQ(body.toString(), expected_body);
 }
 
-TEST_F(InjaTransformerTest, RenderBodyAsJsonRawStringCallback) {
+TEST_F(InjaTransformerTest, RawStringCallbackTooManyArguments) {
+  TransformationTemplate transformation;
+  transformation.mutable_body()->set_text(
+      R"EOF({% set bad="extra argument to function" %}{"Value":"{{ raw_string(value, bad) }}"})EOF");
+  EXPECT_THROW_WITH_REGEX(InjaTransformer transformer(transformation, rng_, google::protobuf::BoolValue(), tls_), EnvoyException, ".*unknown function raw_string.*")
+}
+
+TEST_F(InjaTransformerTest, RawStringCallbackZeroArguments) {
+  TransformationTemplate transformation;
+  transformation.mutable_body()->set_text(
+      R"EOF({"Value":"{{ raw_string() }}"})EOF");
+  EXPECT_THROW_WITH_REGEX(InjaTransformer transformer(transformation, rng_, google::protobuf::BoolValue(), tls_), EnvoyException, ".*unknown function raw_string.*")
+}
+
+
+TEST_F(InjaTransformerTest, EscapeCharactersRawStringCallback) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo"}};
   TransformationTemplate transformation;
   transformation.mutable_body()->set_text(
       R"EOF({"Value":"{{ raw_string(value) }}"})EOF");
-  transformation.set_render_body_as_json(true);
+  transformation.set_escape_characters(true);
   InjaTransformer transformer(transformation, rng_, google::protobuf::BoolValue(), tls_);
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -1159,10 +1159,7 @@ TEST_F(InjaTransformerTest, RenderBodyAsJson) {
 
   Buffer::OwnedImpl body(R"({"value":"\"foo\""})"_json.dump());
   auto expected_body = R"({"Value":"\"foo\""})"_json.dump();
-  std::cout << "body.toString() before: " << body.toString() << std::endl;
   transformer.transform(headers, &headers, body, callbacks);
-  std::cout << "body.toString() after: " << body.toString() << std::endl;
-  std::cout << "expected_body: " << expected_body << std::endl;
   EXPECT_EQ(body.toString(), expected_body);
 }
 

--- a/test/integration/transformation_filter_integration_test.cc
+++ b/test/integration/transformation_filter_integration_test.cc
@@ -124,22 +124,6 @@ const std::string PASSTHROUGH_TRANSFORMATION =
       passthrough: {}
 )EOF";
 
-const std::string RENDER_BODY_AS_JSON_TRANSFORMATION =
-    R"EOF(
-  request_transformation:
-    transformation_template:
-      advanced_templates: false
-      render_body_as_json: true
-      body:
-        text: "{\"Foo\":\"{{ foo }}\"}"
-  response_transformation:
-    transformation_template:
-      advanced_templates: false
-      render_body_as_json: true
-      body:
-        text: "{\"Bar\":\"{{ bar }}\"}"
-)EOF";
-
 const std::string DEFAULT_FILTER_TRANSFORMATION =
     R"EOF(
       {}

--- a/test/integration/transformation_filter_integration_test.cc
+++ b/test/integration/transformation_filter_integration_test.cc
@@ -537,4 +537,49 @@ TEST_P(TransformationFilterIntegrationTest, RenderBodyAsJsonTransform) {
   auto expected_response_body = R"({"Bar":"\"baz\""})"_json;
   EXPECT_EQ(expected_response_body, actual_response_body);
 }
+
+TEST_P(TransformationFilterIntegrationTest, RenderBodyAsJsonTransformEscapedInput) {
+  using json = nlohmann::json;
+  transformation_string_ =
+    R"EOF(
+  request_transformation:
+    transformation_template:
+      advanced_templates: false
+      render_body_as_json: false
+      body:
+        text: "{\"Foo\":\"{{ foo }}\"}"
+  response_transformation:
+    transformation_template:
+      advanced_templates: false
+      render_body_as_json: false
+      body:
+        text: "{\"Bar\":\"{{ bar }}\"}"
+)EOF";
+  initialize();
+  std::string origReqBody = R"EOF({"foo":"\\\"bar\\\""})EOF";
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":authority", "www.solo.io"},
+                                                 {":path", "/"}};
+  auto encoder_decoder = codec_client_->startRequest(request_headers);
+
+  auto downstream_request = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  Buffer::OwnedImpl data(origReqBody);
+  codec_client_->sendData(*downstream_request, data, true);
+
+  processRequest(response, R"EOF({"bar":"\\\"baz\\\""})EOF");
+
+  auto actual_request_body = json::parse(upstream_request_->body().toString());
+  auto expected_request_body = R"({"Foo":"\"bar\""})"_json;
+
+  // make sure response works as well, with no metadata set:
+  EXPECT_EQ(expected_request_body, actual_request_body);
+
+  json actual_response_body = json::parse(response->body());
+  // remove the `x-envoy-upstream-service-time` since its
+  // value depends on how long the test took to run
+  auto expected_response_body = R"({"Bar":"\"baz\""})"_json;
+  EXPECT_EQ(expected_response_body, actual_response_body);
+}
 } // namespace Envoy


### PR DESCRIPTION
Users have the issue that when they transform a request or response body that includes escaped characters, for example this json request/response body 
```json
{
  "foo": "{\"bar\":\"baz\"}"
}
```

The characters lose their escaping when used in a template e.g. the template `{"response":"{{ foo }}"}` would produce the string 
```json
{"response":"{"bar":"baz"}"}
```

which is not valid JSON since the quotes are not escaped. Instead we expect to be able to produce
```json
{"response":"{\"bar\":\"baz\"}"}
```

This PR provides 2 methods of achieving this
- The new callback `raw_string` can be used to escape a particular value within a template.
  - e.g. the template would look like `{"response":"{{ raw_string(foo) }}"}`
- The transformation itself can be configured to do this for all string values found in the body and rendered in the template.
  - This is the new setting `render_body_as_json` on the `TransformationTemplate` setting