### PR TITLE
[v1.23] Bump envoy to v1.23.12 to resolve CVEs

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
-    # envoy 1.23.11, commit: https://github.com/envoyproxy/envoy/commit/84dd90f2220ca8661b67d7efa1f93d67e1218222
+    # envoy 1.23.12, commit: https://github.com/envoyproxy/envoy/commit/9689bc57f80fe56dbb16a4e0d632cde5363d1811
     envoy = dict(
-        commit = "84dd90f2220ca8661b67d7efa1f93d67e1218222",
+        commit = "9689bc57f80fe56dbb16a4e0d632cde5363d1811",
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(

--- a/changelog/v1.23.12-patch1/bump-envoy-jul25.yaml
+++ b/changelog/v1.23.12-patch1/bump-envoy-jul25.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: envoyproxy
+  dependencyRepo: envoy
+  dependencyTag: v1.23.12
+  description: > 
+    Bump envoy to v1.23.12
+    This resolves CVE-2023-35941, CVE-2023-35942, CVE-2023-35944, and CVE-2023-35945


### PR DESCRIPTION
 - Bump envoy to v1.23.12
 - This resolves CVE-2023-35941, CVE-2023-35942, CVE-2023-35944, and CVE-2023-35945