### PR TITLE
[v1.25] Bump envoy to v1.25.9

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
-        # envoy 1.25.8
-        commit = "63ec332cbacd277f8937b4eca71f8e1629e4c1f7",
+        # envoy 1.25.9
+        commit = "820698ea5c3f4245ac1e1e381c01155e28d6db09",
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(

--- a/changelog/v1.25.9-patch1/upgrade-envoy.yaml
+++ b/changelog/v1.25.9-patch1/upgrade-envoy.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: envoyproxy
+  dependencyRepo: envoy
+  dependencyTag: v1.25.9
+  description: > 
+    Bump envoy to v1.25.9
+    This resolves CVE-2023-35941, CVE-2023-35942, CVE-2023-35944, and CVE-2023-35945


### PR DESCRIPTION
 - Bump envoy to v1.25.9
 - This resolves CVE-2023-35941, CVE-2023-35942, CVE-2023-35944, and CVE-2023-35945