### PR TITLE
[main/v1.26] Bump envoy to pre-1.26.4 commit

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,8 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
-        # envoy 1.26.3
-        commit = "ea9d25e93cef74b023c95ca1a3f79449cdf7fa9a",
+        # pre-1.26.4 commit -- https://github.com/envoyproxy/envoy/commit/ac06249e76fbe2c427678c1c9d85c88675d6129e
+        # using pre-release commit due to upstream build issues
+        commit = "ac06249e76fbe2c427678c1c9d85c88675d6129e",
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(

--- a/changelog/v1.26.4-patch1/envoy-bump.yaml
+++ b/changelog/v1.26.4-patch1/envoy-bump.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyRepo: envoy
+    dependencyOwner: envoyproxy
+    dependencyTag: ac06249e76fbe2c427678c1c9d85c88675d6129e
+    description: >
+      Bump Envoy to ac06249e76fbe2c427678c1c9d85c88675d6129e to pull in fixes for
+      CVE-2023-35941, CVE-2023-35942, CVE-2023-35944, and CVE-2023-35945


### PR DESCRIPTION
 - Bump Envoy to ac06249e76fbe2c427678c1c9d85c88675d6129e to pull in fixes for CVE-2023-35941, CVE-2023-35942, CVE-2023-35944, and CVE-2023-35945