### PR TITLE
bazel: Switch to envoy fork

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -2,7 +2,7 @@ REPOSITORY_LOCATIONS = dict(
     envoy = dict(
         # envoy 1.26.4 forked with extproc changes
         # sourced from release/v1.26-backportedfork
-        commit = "70d22dc31869194bcdc0841390ef468a3a4eab1b",
+        commit = "f854df5872c0a632774a78537a63d0f6ec4b370b",
         remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,8 +1,9 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
-        # envoy 1.26.4
-        commit = "cfa32deca25ac57c2bbecdad72807a9b13493fc1",
-        remote = "https://github.com/envoyproxy/envoy",
+        # envoy 1.26.4 forked with extproc changes
+        # sourced from release/v1.26-backportedfork
+        commit = "70d22dc31869194bcdc0841390ef468a3a4eab1b",
+        remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(
         # Includes unmerged modifications for

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -2,6 +2,7 @@ REPOSITORY_LOCATIONS = dict(
     envoy = dict(
         # envoy 1.26.4 forked with extproc changes
         # sourced from release/v1.26-backportedfork
+        # should go back to upstream once 1.27 or whever the associated prs are merged
         commit = "f854df5872c0a632774a78537a63d0f6ec4b370b",
         remote = "https://github.com/solo-io/envoy-fork",
     ),

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -2,7 +2,7 @@ REPOSITORY_LOCATIONS = dict(
     envoy = dict(
         # envoy 1.26.4 forked with extproc changes
         # sourced from release/v1.26-backportedfork
-        # should go back to upstream once 1.27 or whever the associated prs are merged
+        # should go back to upstream once 1.28or wherever the associated prs are merged
         commit = "f854df5872c0a632774a78537a63d0f6ec4b370b",
         remote = "https://github.com/solo-io/envoy-fork",
     ),

--- a/changelog/v1.26.4-patch2/envoy-fork.yaml
+++ b/changelog/v1.26.4-patch2/envoy-fork.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyRepo: envoy-fork
+    dependencyOwner: solo-io
+    dependencyTag: v1.26.4
+    description: >
+      Migrate to fork that is based off of 1.26.4. It includes long term backports.
+      These backports are not fully merged upstream but make external processing actually function as needed.
+      Notably this implements several long time api notes that were never implemeented before.


### PR DESCRIPTION
Switch over to a branch of envoy fork that includes both external processing metadata but also a work around for local reply issues.

https://github.com/envoyproxy/envoy/pull/29069

https://github.com/envoyproxy/envoy/pull/29459