### PR TITLE
[v1.23] Backport Handle STS Credentials Region (#267)

### DIFF
--- a/api/envoy/config/filter/http/aws_lambda/v2/aws_lambda.proto
+++ b/api/envoy/config/filter/http/aws_lambda/v2/aws_lambda.proto
@@ -101,6 +101,10 @@ message AWSLambdaConfig {
     string uri = 2 [ (validate.rules).string.min_bytes = 1 ];
     // timeout for the request
     google.protobuf.Duration timeout = 3;
+    // Region for the sts endpoint, defaults to us-east-1. 
+    // This must be an enabled region https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
+    // This should match the region specified in the uri.
+    string region = 4;
   }
 
   // Send downstream path and method as `x-envoy-original-path` and

--- a/changelog/v1.23.12-patch2/handle-sts-credentials-region.yaml
+++ b/changelog/v1.23.12-patch2/handle-sts-credentials-region.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/8578
+  resolvesIssue: false 
+  description: >
+    Support role chaining using EKS ServiceAccounts outside of us-east-1

--- a/source/extensions/filters/http/aws_lambda/sts_connection_pool.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_connection_pool.cc
@@ -28,6 +28,7 @@ public:
   ~StsConnectionPoolImpl();
 
   void init(const envoy::config::core::v3::HttpUri &uri,
+            const std::string region,
             const absl::string_view web_token,
             StsCredentialsConstSharedPtr creds) override;
   void setInFlight() override;
@@ -112,9 +113,10 @@ StsConnectionPoolImpl::~StsConnectionPoolImpl() {
 };
 
 void StsConnectionPoolImpl::init(const envoy::config::core::v3::HttpUri &uri,
+        const std::string region,
         const absl::string_view web_token, StsCredentialsConstSharedPtr creds) {
   request_in_flight_ = true;
-  fetcher_->fetch(uri, role_arn_, web_token, creds, this);
+  fetcher_->fetch(uri, region, role_arn_, web_token, creds, this);
 }
 void StsConnectionPoolImpl::setInFlight() {
   request_in_flight_ = true;

--- a/source/extensions/filters/http/aws_lambda/sts_connection_pool.h
+++ b/source/extensions/filters/http/aws_lambda/sts_connection_pool.h
@@ -106,6 +106,7 @@ public:
   using ContextPtr = std::unique_ptr<Context>;
 
   virtual void init(const envoy::config::core::v3::HttpUri &uri,
+    const std::string region,
     const absl::string_view web_token, StsCredentialsConstSharedPtr creds) PURE;
   virtual void setInFlight() PURE;
   virtual Context *add(StsConnectionPool::Context::Callbacks *callback) PURE;

--- a/source/extensions/filters/http/aws_lambda/sts_fetcher.cc
+++ b/source/extensions/filters/http/aws_lambda/sts_fetcher.cc
@@ -34,6 +34,7 @@ public:
   }
 
   void fetch(const envoy::config::core::v3::HttpUri &uri,
+             const std::string region,
              const absl::string_view role_arn,
              const absl::string_view web_token,
              StsCredentialsConstSharedPtr creds,
@@ -97,9 +98,17 @@ public:
         &creds->secretAccessKey().value(), &creds->sessionToken().value());
     aws_authenticator.updatePayloadHash(message->body());
     auto& hdrs = message->headers();
-    // TODO(nfuden) allow for Region this to be overridable. 
-    // DefaultRegion is gauranteed to be available but an override may be faster
-    aws_authenticator.sign(&hdrs, HeadersToSign, DefaultRegion);
+    // region should never be NULL at this point, but if it is, we can use the 
+    // default region.
+    if (!region.empty()){
+      ENVOY_LOG(debug, "assume chained role from [uri = {}]: region is {}", 
+                                                                uri_->uri(), region);
+      aws_authenticator.sign(&hdrs, HeadersToSign, region);
+    } else {
+      ENVOY_LOG(debug, "assume chained role from [uri = {}]: region is empty, using default region",
+                                                                uri_->uri());
+      aws_authenticator.sign(&hdrs, HeadersToSign, DefaultRegion);
+    }
     // Log the accessKey but not the secret. This is to show that we have valid 
     // credentials but does not leak anything secret. This is due to our
     // sessions being 
@@ -140,6 +149,10 @@ public:
         // TODO: cover more AWS error cases
         if (body.find(ExpiredTokenError) != std::string::npos) {
           callbacks_->onFailure(CredentialsFailureStatus::ExpiredToken);
+        } else if (body.find(SignaturedoesNotMatchError) != std::string::npos &&
+                   body.find(CredentialScopeMessage) != std::string::npos )
+        {
+          callbacks_->onFailure(CredentialsFailureStatus::CredentialScopeMismatch);
         } else {
           callbacks_->onFailure(CredentialsFailureStatus::Network);
         }

--- a/source/extensions/filters/http/aws_lambda/sts_fetcher.h
+++ b/source/extensions/filters/http/aws_lambda/sts_fetcher.h
@@ -25,6 +25,8 @@ namespace {
     "Version=2011-06-15";
 
 constexpr char ExpiredTokenError[] = "ExpiredTokenException";
+constexpr char SignaturedoesNotMatchError[] = "SignatureDoesNotMatch";
+constexpr char CredentialScopeMessage[] = "Credential should be scoped to a valid region.";
 } // namespace
 
 class StsCredentials : public Extensions::Common::Aws::Credentials {
@@ -98,6 +100,7 @@ public:
    * @param failure the cb called on failed role assumption
    */
   virtual void fetch(const envoy::config::core::v3::HttpUri &uri,
+                     const std::string region,
                      const absl::string_view role_arn,
                      const absl::string_view web_token,
                      StsCredentialsConstSharedPtr creds,

--- a/source/extensions/filters/http/aws_lambda/sts_status.h
+++ b/source/extensions/filters/http/aws_lambda/sts_status.h
@@ -16,7 +16,9 @@ enum class CredentialsFailureStatus {
   /* Token is expired. */
   ClusterNotFound,
   /* The filter is being destroyed, therefore the request should be cancelled */
-  ContextCancelled
+  ContextCancelled,
+  /* The credentials computed by the filter are not valid in the current region */
+  CredentialScopeMismatch,
 };
 
 } // namespace AwsLambda

--- a/test/extensions/filters/http/aws_lambda/mocks.h
+++ b/test/extensions/filters/http/aws_lambda/mocks.h
@@ -20,6 +20,7 @@ public:
   MOCK_METHOD(void, cancel, ());
   MOCK_METHOD(void, fetch,
               (const envoy::config::core::v3::HttpUri &uri,
+               const std::string region,
                const absl::string_view role_arn,
                const absl::string_view web_token,
                StsCredentialsConstSharedPtr creds,
@@ -92,6 +93,7 @@ public:
               (StsConnectionPool::Context::Callbacks * callback));
   MOCK_METHOD(void, init,
               (const envoy::config::core::v3::HttpUri &uri,
+               const std::string region,
                const absl::string_view web_token,
                StsCredentialsConstSharedPtr creds));
   MOCK_METHOD(void, addChained, (std::string role_arn));

--- a/test/extensions/filters/http/aws_lambda/sts_credentials_provider_test.cc
+++ b/test/extensions/filters/http/aws_lambda/sts_credentials_provider_test.cc
@@ -98,7 +98,7 @@ TEST_F(StsCredentialsProviderTest, TestFullFlow) {
         return std::move(unique_pool);
       }));
 
-  EXPECT_CALL(*sts_connection_pool, init(_, _, _, _))
+  EXPECT_CALL(*sts_connection_pool_, init(_, _, _, _))
       .WillOnce(Invoke([&](const envoy::config::core::v3::HttpUri &uri,
                            const std::string region,
                            const absl::string_view web_token,
@@ -196,7 +196,7 @@ TEST_F(StsCredentialsProviderTest, TestFullChainedFlow) {
       }));
     
   // expect the base pool to be initialized with fetch
-  EXPECT_CALL(*sts_connection_pool, init(_, _, _, _))
+  EXPECT_CALL(*sts_connection_pool_, init(_, _, _, _))
       .WillOnce(Invoke([&](const envoy::config::core::v3::HttpUri &uri,
                            const std::string region,
                            const absl::string_view web_token,
@@ -271,7 +271,7 @@ TEST_F(StsCredentialsProviderTest, TestUnchainedFlow) {
         return std::move(unique_pool);
       }));
 
-  EXPECT_CALL(*sts_connection_pool, init(_, _, _, _))
+  EXPECT_CALL(*sts_connection_pool_, init(_, _, _, _))
       .WillOnce(Invoke([&](const envoy::config::core::v3::HttpUri &uri,
                            const std::string region,
                            const absl::string_view web_token,

--- a/test/extensions/filters/http/aws_lambda/sts_credentials_provider_test.cc
+++ b/test/extensions/filters/http/aws_lambda/sts_credentials_provider_test.cc
@@ -45,7 +45,8 @@ std::chrono::seconds expiry_time(4120492825);
 
 const std::string service_account_credentials_config = R"(
 cluster: test
-uri: https://foo.com
+uri: https://sts.us-east-1.amazonaws.com
+region: us-east-1
 timeout: 1s
 )";
 
@@ -97,13 +98,15 @@ TEST_F(StsCredentialsProviderTest, TestFullFlow) {
         return std::move(unique_pool);
       }));
 
-  EXPECT_CALL(*sts_connection_pool_, init(_, _, _))
+  EXPECT_CALL(*sts_connection_pool, init(_, _, _, _))
       .WillOnce(Invoke([&](const envoy::config::core::v3::HttpUri &uri,
+                           const std::string region,
                            const absl::string_view web_token,
                            StsCredentialsConstSharedPtr ) {
         EXPECT_EQ(web_token, token);
         EXPECT_EQ(uri.uri(), config_.uri());
         EXPECT_EQ(uri.cluster(), config_.cluster());
+        EXPECT_EQ(region, config_.region());
       }));
   EXPECT_CALL(*sts_connection_pool_, add(_));
 
@@ -193,13 +196,15 @@ TEST_F(StsCredentialsProviderTest, TestFullChainedFlow) {
       }));
     
   // expect the base pool to be initialized with fetch
-  EXPECT_CALL(*sts_connection_pool_, init(_, _, _))
+  EXPECT_CALL(*sts_connection_pool, init(_, _, _, _))
       .WillOnce(Invoke([&](const envoy::config::core::v3::HttpUri &uri,
+                           const std::string region,
                            const absl::string_view web_token,
                            StsCredentialsConstSharedPtr ) {
         EXPECT_EQ(web_token, token);
         EXPECT_EQ(uri.uri(), config_.uri());
         EXPECT_EQ(uri.cluster(), config_.cluster());
+        EXPECT_EQ(region, config_.region());
       }));
 
   EXPECT_CALL(*sts_chained_connection_pool_, setInFlight());
@@ -266,13 +271,15 @@ TEST_F(StsCredentialsProviderTest, TestUnchainedFlow) {
         return std::move(unique_pool);
       }));
 
-  EXPECT_CALL(*sts_connection_pool_, init(_, _, _))
+  EXPECT_CALL(*sts_connection_pool, init(_, _, _, _))
       .WillOnce(Invoke([&](const envoy::config::core::v3::HttpUri &uri,
+                           const std::string region,
                            const absl::string_view web_token,
                            StsCredentialsConstSharedPtr ) {
         EXPECT_EQ(web_token, token);
         EXPECT_EQ(uri.uri(), config_.uri());
         EXPECT_EQ(uri.cluster(), config_.cluster());
+        EXPECT_EQ(region, config_.region());
       }));
   EXPECT_CALL(*sts_connection_pool_, add(_));
 

--- a/test/extensions/filters/http/aws_lambda/sts_fetcher_test.cc
+++ b/test/extensions/filters/http/aws_lambda/sts_fetcher_test.cc
@@ -52,6 +52,16 @@ const std::string expired_token_response = R"(
 </ErrorResponse>
 )";
 
+const std::string credential_scope_mismatch = R"(
+  <ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <Error>
+    <Type>Sender</Type>
+    <Code>SignatureDoesNotMatch</Code>
+    <Message>Credential should be scoped to a valid region. </Message>
+  </Error>
+</ErrorResponse>
+)";
+
 const std::string valid_chained_response = R"(
   <AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <AssumeRoleResult>
@@ -81,6 +91,7 @@ const std::string service_account_credentials_config = R"(
 cluster: test
 uri: https://foo.com
 timeout: 1s
+region: us-east-1
 )";
 
 const std::string role_arn = "role_arn";
@@ -92,9 +103,15 @@ public:
   void SetUp() override {
     mock_factory_ctx_.cluster_manager_.initializeClusters({"test"}, {});
     mock_factory_ctx_.cluster_manager_.initializeThreadLocalClusters({"test"});
-    TestUtility::loadFromYaml(service_account_credentials_config, uri_);
+    TestUtility::loadFromYaml(service_account_credentials_config, config_);
+    uri_.set_cluster(config_.cluster());
+    uri_.set_uri(config_.uri());
+    region_ = config_.region();
   }
+
+  envoy::config::filter::http::aws_lambda::v2::AWSLambdaConfig_ServiceAccountCredentials config_;
   HttpUri uri_;
+  std::string region_;
   testing::NiceMock<Server::Configuration::MockFactoryContext>
       mock_factory_ctx_;
 };
@@ -111,7 +128,7 @@ TEST_F(StsFetcherTest, TestGetSuccess) {
   testing::NiceMock<MockStsFetcherCallbacks> callbacks;
   EXPECT_CALL(callbacks, onSuccess(valid_response)).Times(1);
   // Act
-  fetcher->fetch(uri_, role_arn, web_token, NULL, &callbacks);
+  fetcher->fetch(uri_, region_, role_arn, web_token, NULL, &callbacks);
 }
 
 TEST_F(StsFetcherTest, TestChainedSts) {
@@ -135,7 +152,7 @@ TEST_F(StsFetcherTest, TestChainedSts) {
                         access_key, secret_key, session_token, expiration_time);
 
   // Act
-  fetcher->fetch(uri_, to_chain_role_arn, "", sub_creds, &callbacks);
+  fetcher->fetch(uri_, region_, to_chain_role_arn, "", sub_creds, &callbacks);
 }
 
 TEST_F(StsFetcherTest, TestGet503) {
@@ -149,7 +166,7 @@ TEST_F(StsFetcherTest, TestGet503) {
   EXPECT_CALL(callbacks, onFailure(CredentialsFailureStatus::Network)).Times(1);
 
   // Act
-  fetcher->fetch(uri_, role_arn, web_token, NULL, &callbacks);
+  fetcher->fetch(uri_, region_, role_arn, web_token, NULL, &callbacks);
 }
 
 TEST_F(StsFetcherTest, TestCredentialsExpired) {
@@ -165,7 +182,23 @@ TEST_F(StsFetcherTest, TestCredentialsExpired) {
       .Times(1);
 
   // Act
-  fetcher->fetch(uri_, role_arn, web_token, NULL, &callbacks);
+  fetcher->fetch(uri_, region_, role_arn, web_token, NULL, &callbacks);
+}
+
+TEST_F(StsFetcherTest, TestCredentialScopeMismatch) {
+  // Setup
+  MockUpstream mock_sts(mock_factory_ctx_.cluster_manager_, "401",
+                        credential_scope_mismatch);
+  std::unique_ptr<StsFetcher> fetcher(StsFetcher::create(
+      mock_factory_ctx_.cluster_manager_, mock_factory_ctx_.api_));
+  EXPECT_TRUE(fetcher != nullptr);
+
+  testing::NiceMock<MockStsFetcherCallbacks> callbacks;
+  EXPECT_CALL(callbacks, onFailure(CredentialsFailureStatus::CredentialScopeMismatch))
+      .Times(1);
+
+  // Act
+  fetcher->fetch(uri_, region_, role_arn, web_token, NULL, &callbacks);
 }
 
 TEST_F(StsFetcherTest, TestHttpFailure) {
@@ -180,7 +213,7 @@ TEST_F(StsFetcherTest, TestHttpFailure) {
   EXPECT_CALL(callbacks, onFailure(CredentialsFailureStatus::Network)).Times(1);
 
   // Act
-  fetcher->fetch(uri_, role_arn, web_token, NULL, &callbacks);
+  fetcher->fetch(uri_, region_, role_arn, web_token, NULL, &callbacks);
 }
 
 TEST_F(StsFetcherTest, TestCancel) {
@@ -196,7 +229,7 @@ TEST_F(StsFetcherTest, TestCancel) {
   testing::NiceMock<MockStsFetcherCallbacks> callbacks;
 
   // Act
-  fetcher->fetch(uri_, role_arn, web_token, NULL, &callbacks);
+  fetcher->fetch(uri_, region_, role_arn, web_token, NULL, &callbacks);
   // Proper cancel
   fetcher->cancel();
   // Re-entrant cancel

--- a/test/integration/aws_lambda_filter_integration_test.cc
+++ b/test/integration/aws_lambda_filter_integration_test.cc
@@ -31,6 +31,7 @@ typed_config:
   service_account_credentials:
     cluster: cluster_0
     uri: https://foo.com
+    region: us-east-1
     timeout: 1s
 )EOF";
 


### PR DESCRIPTION
# Description
 - Backport #267 to v1.23.x
 - This resolves an issue where assuming a secondary role using an EKS ServiceAccount would fail when the region of the EKS cluster/OIDC provider used to authenticate the assumeRole request was not us-east-1