### PR TITLE
ci: Update the intermediate image that gets emitted to no longer rely…

### DIFF
--- a/changelog/v1.27.0-patch2/updatebuild-image.yaml
+++ b/changelog/v1.27.0-patch2/updatebuild-image.yaml
@@ -1,0 +1,18 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/5344
+    resolvesIssue: false
+    description: > 
+      Migrate from alpine to ubuntu for released version. 
+      Backlogged an issue to move fully to distroless on beta branch.
+      Can be found here https://github.com/solo-io/solo-projects/issues/5388
+      Not migrating prior as this may impact some debugging steps.
+      Forced to migrate per glibc being unable to update.
+      https://nvd.nist.gov/vuln/detail/CVE-2022-23218
+      https://nvd.nist.gov/vuln/detail/CVE-2022-23219
+      https://nvd.nist.gov/vuln/detail/CVE-2021-38604
+      https://nvd.nist.gov/vuln/detail/CVE-2021-3998
+      See here for glibc on alpine maintainers
+      https://gitlab.alpinelinux.org/alpine/tsc/-/issues/43#note_306270
+      https://github.com/sgerrand/alpine-pkg-glibc/issues/207#issuecomment-1707209887
+      https://github.com/sgerrand/alpine-pkg-glibc/issues/176

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,17 +1,23 @@
-# This file was inspired by envoy Dockerfile:
-# https://github.com/envoyproxy/envoy/blob/445a67344ffda0c8828c8e438e463fcaa7878434/ci/Dockerfile-envoy-alpine
-
-FROM frolvlad/alpine-glibc:alpine-3.17_glibc-2.34
+# This file was inspired by mesh Dockerfile:
+# https://github.com/solo-io/gloo-mesh-enterprise/blob/c40b21c3ef260de1acc92ba25bd1794b17074c8c/docker/Dockerfile.ubuntu#L4
+# as it previously was based off of envoys old alpine setup. 
+FROM ubuntu:focal-20220826
 
 ENV loglevel=info
 
-RUN apk upgrade --update-cache \
-    && apk add dumb-init ca-certificates \
-    && rm -rf /var/cache/apk/*
+ENV DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3005,DL3008
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  ca-certificates \
+  && apt-get upgrade -y \
+  && apt-get clean \
+  && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
 
 RUN mkdir -p /etc/envoy
 
 ADD envoy.stripped /usr/local/bin/envoy
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/bin/envoy"]
+ENTRYPOINT ["/usr/local/bin/envoy"]
 CMD ["-c", "/etc/envoy/envoy.yaml"]


### PR DESCRIPTION
Move to ubuntu for now.
This can be migrated to distroless in solo-projects if need be in the future but would need to have ubuntu for symbols anyways if we want to follow upstream's behavior.

https://gitlab.alpinelinux.org/alpine/tsc/-/issues/43#note_306270
https://github.com/sgerrand/alpine-pkg-glibc/issues/207#issuecomment-1707209887
https://github.com/sgerrand/alpine-pkg-glibc/issues/176