### PR TITLE
bump: 1.25.10 for CVE-2023-44487

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
-        # envoy 1.25.9
-        commit = "7b2609e12147377b0420bfa4453762e377f218f3",
+        # envoy 1.25.10
+        commit = "e208fc2a0e104141100b001613a8932c52e4cee7",
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(

--- a/changelog/v1.25.10-patch1/upgrade-envoy.yaml
+++ b/changelog/v1.25.10-patch1/upgrade-envoy.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: envoyproxy
+  dependencyRepo: envoy
+  dependencyTag: v1.25.10
+  description: > 
+    Bump envoy to v1.25.10
+    This resolves CVE-2023-44487 


### PR DESCRIPTION
Bump envoy to pick up fix for CVE-2023-44487