### PR TITLE
[v1.25] Backport Unified Matcher Support

### DIFF
--- a/api/envoy/config/filter/http/transformation/v2/BUILD
+++ b/api/envoy/config/filter/http/transformation/v2/BUILD
@@ -16,6 +16,7 @@ api_proto_package(
         "@envoy_api//envoy/type:pkg",
         "@envoy_api//envoy/type/matcher/v3:pkg",
         "@envoy_api//envoy/type/matcher:pkg",
+        "@com_github_cncf_udpa//xds/type/matcher/v3:pkg",
     ],
     visibility = ["//visibility:public"],
 )

--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -11,6 +11,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 import "validate/validate.proto";
 
+import "xds/type/matcher/v3/matcher.proto";
 import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/config/core/v3/extension.proto";
@@ -20,6 +21,9 @@ message FilterTransformations {
   // transformation will be applied. If there are overlapped match conditions,
   // please put the most specific match first.
   repeated TransformationRule transformations = 1;
+
+  // If provided, transformations fields here are ignored. The transformation will be the action from this matcher.
+  xds.type.matcher.v3.Matcher matcher = 4;
 
   // Only RouteTransformations.RouteTransformation with matching stage will be
   // used with this filter.
@@ -96,9 +100,13 @@ message RouteTransformations {
       RequestMatch request_match = 2;
       ResponseMatch response_match = 3;
     }
+    // If provided, transformations with request_match in transformations field are ignored.
+    // The transformation will be the action from this matcher.
+    xds.type.matcher.v3.Matcher matcher = 5;
   }
 
   repeated RouteTransformation transformations = 4;
+
 }
 
 message ResponseMatcher {

--- a/changelog/v1.25.10-patch2/transformation-matcher.yaml
+++ b/changelog/v1.25.10-patch2/transformation-matcher.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/12181
+  resolvesIssue: false
+  description: >-
+    Support using unified matcher API for transformation filter.

--- a/source/common/matcher/BUILD
+++ b/source/common/matcher/BUILD
@@ -24,3 +24,9 @@ envoy_cc_library(
     ],
 )
 
+# CC library for data_impl.h
+envoy_cc_library(
+    name = "solo_matcher_data_impl_lib",
+    hdrs = ["data_impl.h"],
+    repository = "@envoy",
+)

--- a/source/common/matcher/data_impl.h
+++ b/source/common/matcher/data_impl.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "envoy/http/filter.h"
+#include "envoy/server/factory_context.h"
+
+namespace Envoy {
+namespace Http {
+namespace Matching {
+
+/**
+ * Implementation of HttpMatchingData, providing HTTP specific data to
+ * the match tree.
+ */
+// Backported from envoy v1.27
+class SoloHttpMatchingDataImpl : public HttpMatchingData {
+public:
+  explicit SoloHttpMatchingDataImpl(const StreamInfo::StreamInfo& stream_info)
+      : stream_info_(stream_info) {}
+
+  static absl::string_view name() { return "http"; }
+
+  void onRequestHeaders(const RequestHeaderMap& request_headers) {
+    request_headers_ = &request_headers;
+  }
+
+  void onRequestTrailers(const RequestTrailerMap& request_trailers) {
+    request_trailers_ = &request_trailers;
+  }
+
+  void onResponseHeaders(const ResponseHeaderMap& response_headers) {
+    response_headers_ = &response_headers;
+  }
+
+  void onResponseTrailers(const ResponseTrailerMap& response_trailers) {
+    response_trailers_ = &response_trailers;
+  }
+
+  RequestHeaderMapOptConstRef requestHeaders() const override {
+    return makeOptRefFromPtr(request_headers_);
+  }
+
+  RequestTrailerMapOptConstRef requestTrailers() const override {
+    return makeOptRefFromPtr(request_trailers_);
+  }
+
+  ResponseHeaderMapOptConstRef responseHeaders() const override {
+    return makeOptRefFromPtr(response_headers_);
+  }
+
+  ResponseTrailerMapOptConstRef responseTrailers() const override {
+    return makeOptRefFromPtr(response_trailers_);
+  }
+
+  const StreamInfo::StreamInfo& streamInfo() const { return stream_info_; }
+
+  const Network::ConnectionInfoProvider& connectionInfoProvider() const override {
+    return stream_info_.downstreamAddressProvider();
+  }
+
+private:
+  const StreamInfo::StreamInfo& stream_info_;
+  const RequestHeaderMap* request_headers_{};
+  const ResponseHeaderMap* response_headers_{};
+  const RequestTrailerMap* request_trailers_{};
+  const ResponseTrailerMap* response_trailers_{};
+};
+
+using SoloHttpMatchingDataImplSharedPtr = std::shared_ptr<SoloHttpMatchingDataImpl>;
+} // namespace Matching
+} // namespace Http
+} // namespace Envoy

--- a/source/common/matcher/data_impl.h
+++ b/source/common/matcher/data_impl.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "envoy/http/filter.h"
-#include "envoy/server/factory_context.h"
 
 namespace Envoy {
 namespace Http {

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/filters/http/aws_lambda/config.h"
 
 #include "source/extensions/filters/http/transformation/transformation_filter_config.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
 
 #include "envoy/thread_local/thread_local.h"
 

--- a/source/extensions/filters/http/transformation/BUILD
+++ b/source/extensions/filters/http/transformation/BUILD
@@ -193,7 +193,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":transformation_filter_lib",
-        "//source/common/matcher:matchers_data_impl_lib",
+        "//source/common/matcher:solo_matcher_data_impl_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy//source/extensions/filters/http/common:factory_base_lib",
     ],

--- a/source/extensions/filters/http/transformation/BUILD
+++ b/source/extensions/filters/http/transformation/BUILD
@@ -193,6 +193,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":transformation_filter_lib",
+        "//source/common/matcher:matchers_data_impl_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy//source/extensions/filters/http/common:factory_base_lib",
     ],

--- a/source/extensions/filters/http/transformation/BUILD
+++ b/source/extensions/filters/http/transformation/BUILD
@@ -76,6 +76,7 @@ envoy_cc_library(
         ":transformer_lib",
         ":transformation_factory_lib",
         "//api/envoy/config/filter/http/transformation/v2:pkg_cc_proto",
+        "//source/common/matcher:solo_matcher_data_impl_lib",
         "@envoy//source/common/http/matching:data_impl_lib",
         "@envoy//source/common/matcher:matcher_lib",
     ],

--- a/source/extensions/filters/http/transformation/BUILD
+++ b/source/extensions/filters/http/transformation/BUILD
@@ -30,15 +30,54 @@ envoy_cc_library(
     ],
     repository = "@envoy",
     deps = [
+        ":filter_config_lib",
+        ":transformation_logger_lib",
+        ":transformation_factory_lib",
+        ":matcher_lib",
+        "//source/extensions/filters/http:solo_well_known_names",
+        "//api/envoy/config/filter/http/transformation/v2:pkg_cc_proto",
+        "@envoy//envoy/router:router_interface",
+        "@envoy//envoy/config:typed_config_interface",
+        "@envoy//source/common/protobuf:message_validator_lib",
+    ],
+)
+envoy_cc_library(
+    name = "transformation_factory_lib",
+    srcs = [
+        "transformation_factory.cc",
+    ],
+    hdrs = [
+        "transformation_factory.h",
+    ],
+    repository = "@envoy",
+    deps = [
         ":body_header_transformer_lib",
         ":inja_transformer_lib",
-        ":transformer_lib",
         ":transformation_logger_lib",
         "//source/extensions/filters/http:solo_well_known_names",
         "//api/envoy/config/filter/http/transformation/v2:pkg_cc_proto",
         "@envoy//envoy/router:router_interface",
         "@envoy//envoy/config:typed_config_interface",
         "@envoy//source/common/protobuf:message_validator_lib",
+        "@envoy//source/common/config:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "matcher_lib",
+    srcs = [
+        "matcher.cc",
+    ],
+    hdrs = [
+        "matcher.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":transformer_lib",
+        ":transformation_factory_lib",
+        "//api/envoy/config/filter/http/transformation/v2:pkg_cc_proto",
+        "@envoy//source/common/http/matching:data_impl_lib",
+        "@envoy//source/common/matcher:matcher_lib",
     ],
 )
 
@@ -113,11 +152,29 @@ envoy_cc_library(
     hdrs = [
         "transformer.h",
     ],
+    repository = "@envoy",
+    deps = [
+        "@envoy//envoy/buffer:buffer_interface",
+        "@envoy//envoy/http:header_map_interface",
+        "@envoy//envoy/http:filter_interface",
+        "@envoy//envoy/router:router_interface",
+        "@envoy//source/common/http:header_utility_lib",
+        "@envoy//source/extensions/filters/http/common:factory_base_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_config_lib",
+    hdrs = [
+        "filter_config.h",
+    ],
     srcs = [
-        "transformer.cc",
+        "filter_config.cc",
     ],
     repository = "@envoy",
     deps = [
+        ":transformer_lib",
+        ":matcher_lib",
         "//source/common/matcher:matchers_lib",
         "@envoy//envoy/buffer:buffer_interface",
         "@envoy//envoy/http:header_map_interface",

--- a/source/extensions/filters/http/transformation/body_header_transformer.h
+++ b/source/extensions/filters/http/transformation/body_header_transformer.h
@@ -3,6 +3,7 @@
 #include <map>
 
 #include "source/extensions/filters/http/transformation/transformer.h"
+#include "source/common/http/header_utility.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/http/transformation/filter_config.cc
+++ b/source/extensions/filters/http/transformation/filter_config.cc
@@ -1,5 +1,6 @@
 #include "source/extensions/filters/http/transformation/filter_config.h"
 #include "source/extensions/filters/http/transformation/matcher.h"
+#include "source/common/matcher/data_impl.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -14,7 +15,7 @@ TransformerPairConstSharedPtr
 FilterConfig::findTransformers(const Http::RequestHeaderMap &headers, StreamInfo::StreamInfo& si) const {
   auto match = matcher();
   if (match) {
-      Http::Matching::HttpMatchingDataImpl data(si);
+      Http::Matching::SoloHttpMatchingDataImpl data(si);
       data.onRequestHeaders(headers);
       return matchTransform(std::move(data), match); 
   }

--- a/source/extensions/filters/http/transformation/filter_config.cc
+++ b/source/extensions/filters/http/transformation/filter_config.cc
@@ -1,4 +1,5 @@
-#include "source/extensions/filters/http/transformation/transformer.h"
+#include "source/extensions/filters/http/transformation/filter_config.h"
+#include "source/extensions/filters/http/transformation/matcher.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -9,17 +10,14 @@ namespace {
 constexpr uint64_t MAX_STAGE_NUMBER = 10UL;
 }
 
-TransformerPair::TransformerPair(TransformerConstSharedPtr request_transformer,
-                                 TransformerConstSharedPtr response_transformer,
-                                 TransformerConstSharedPtr on_stream_completion_transformer,
-                                 bool should_clear_cache)
-    : clear_route_cache_(should_clear_cache),
-      request_transformation_(request_transformer),
-      response_transformation_(response_transformer),
-      on_stream_completion_transformation_(on_stream_completion_transformer) {}
-
 TransformerPairConstSharedPtr
-FilterConfig::findTransformers(const Http::RequestHeaderMap &headers) const {
+FilterConfig::findTransformers(const Http::RequestHeaderMap &headers, StreamInfo::StreamInfo& si) const {
+  auto match = matcher();
+  if (match) {
+      Http::Matching::HttpMatchingDataImpl data(si);
+      data.onRequestHeaders(headers);
+      return matchTransform(std::move(data), match); 
+  }
   for (const auto &pair : transformerPairs()) {
     if (pair.matcher()->matches(headers)) {
       return pair.transformer_pair();

--- a/source/extensions/filters/http/transformation/filter_config.h
+++ b/source/extensions/filters/http/transformation/filter_config.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/http/filter.h"
+#include "envoy/http/header_map.h"
+#include "envoy/router/router.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats_macros.h"
+
+#include "source/common/http/header_utility.h"
+#include "source/common/matcher/solo_matcher.h"
+#include "source/common/protobuf/protobuf.h"
+
+#include "source/extensions/filters/http/transformation/transformer.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+/**
+ * All stats for the transformation filter. @see stats_macros.h
+ */
+#define ALL_TRANSFORMATION_FILTER_STATS(COUNTER)                               \
+  COUNTER(request_body_transformations)                                        \
+  COUNTER(request_header_transformations)                                      \
+  COUNTER(response_header_transformations)                                     \
+  COUNTER(response_body_transformations)                                       \
+  COUNTER(request_error)                                                       \
+  COUNTER(response_error)                                                      \
+  COUNTER(on_stream_complete_error)
+
+/**
+ * Wrapper struct for transformation @see stats_macros.h
+ */
+struct TransformationFilterStats {
+  ALL_TRANSFORMATION_FILTER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+class TransformConfig {
+public:
+  virtual ~TransformConfig() {}
+  virtual TransformerPairConstSharedPtr
+  findTransformers(const Http::RequestHeaderMap &headers, StreamInfo::StreamInfo& info) const PURE;
+  virtual TransformerConstSharedPtr
+  findResponseTransform(const Http::ResponseHeaderMap &headers,
+                        StreamInfo::StreamInfo &) const PURE;
+};
+
+class StagedTransformConfig {
+public:
+  virtual ~StagedTransformConfig() {}
+  virtual const TransformConfig *
+  transformConfigForStage(uint32_t stage) const PURE;
+};
+
+class MatcherTransformerPair {
+public:
+  MatcherTransformerPair(Matcher::MatcherConstPtr matcher,
+                         TransformerPairConstSharedPtr transformer_pair)
+      : matcher_(matcher), transformer_pair_(transformer_pair) {}
+
+  TransformerPairConstSharedPtr transformer_pair() const {
+    return transformer_pair_;
+  }
+
+  Matcher::MatcherConstPtr matcher() const { return matcher_; }
+
+private:
+  Matcher::MatcherConstPtr matcher_;
+  TransformerPairConstSharedPtr transformer_pair_;
+};
+
+class FilterConfig : public TransformConfig {
+public:
+  FilterConfig(const std::string &prefix, Stats::Scope &scope, uint32_t stage, bool log_request_response_info)
+      : stats_(generateStats(prefix, scope)), stage_(stage), log_request_response_info_(log_request_response_info) {}
+
+  static TransformationFilterStats generateStats(const std::string &prefix,
+                                                 Stats::Scope &scope);
+
+
+  // Finds the matcher that matched the header
+  TransformerPairConstSharedPtr
+  findTransformers(const Http::RequestHeaderMap &headers, StreamInfo::StreamInfo& info) const override;
+
+  TransformerConstSharedPtr
+  findResponseTransform(const Http::ResponseHeaderMap &,
+                        StreamInfo::StreamInfo &) const override {
+    return nullptr;
+  }
+
+  TransformationFilterStats &stats() { return stats_; }
+
+  virtual std::string name() const PURE;
+
+  uint32_t stage() const { return stage_; }
+
+  bool logRequestResponseInfo() const { return log_request_response_info_; }
+protected:
+
+  virtual const std::vector<MatcherTransformerPair> &
+    transformerPairs() const PURE;
+
+  virtual Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher() const {return nullptr;};
+
+private:
+  TransformationFilterStats stats_;
+  uint32_t stage_{};
+  bool log_request_response_info_{};
+};
+
+class RouteFilterConfig : public Router::RouteSpecificFilterConfig,
+                          public StagedTransformConfig {
+public:
+  RouteFilterConfig();
+
+  const TransformConfig *transformConfigForStage(uint32_t stage) const override;
+
+protected:
+  std::vector<std::unique_ptr<const TransformConfig>> stages_;
+};
+
+typedef std::shared_ptr<const RouteFilterConfig>
+    RouteFilterConfigConstSharedPtr;
+typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
+
+} // namespace Transformation
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -8,6 +8,8 @@
 
 #include "source/common/common/base64.h"
 
+#include "envoy/thread_local/thread_local_object.h"
+#include "envoy/thread_local/thread_local.h"
 #include "source/extensions/filters/http/transformation/transformer.h"
 
 // clang-format off

--- a/source/extensions/filters/http/transformation/matcher.cc
+++ b/source/extensions/filters/http/transformation/matcher.cc
@@ -1,0 +1,97 @@
+#include "api/envoy/config/filter/http/transformation/v2/transformation_filter.pb.validate.h"
+#include "source/extensions/filters/http/transformation/matcher.h"
+#include "source/common/matcher/matcher.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+class TransformationAction : public Envoy::Matcher::ActionBase<envoy::api::v2::filter::http::TransformationRule_Transformations> {
+public:
+  TransformationAction(TransformerPairConstSharedPtr transformations)
+      : transformations_(std::move(transformations)) {}
+
+  TransformerPairConstSharedPtr transformations() const { return transformations_; }
+
+private:
+  const std::string name_;
+  TransformerPairConstSharedPtr transformations_;
+};
+
+TransformerPairConstSharedPtr matchTransform(Http::Matching::HttpMatchingDataImpl&& data, const Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData>& matcher) {
+    auto match = Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher, data);
+    if (match.result_) {
+      auto action = match.result_();
+
+      // The only possible action that can be used within the route matching context
+      // is the TransformationAction, so this must be true.
+      ASSERT(action->typeUrl() == TransformationAction::staticTypeUrl());
+      ASSERT(dynamic_cast<TransformationAction*>(action.get()));
+      const TransformationAction& transformation_action = static_cast<const TransformationAction&>(*action);
+
+      return transformation_action.transformations();
+    }
+    return nullptr;
+}
+
+struct TransformationContext {
+  Server::Configuration::ServerFactoryContext &factory_context;
+};
+
+class ActionFactory : public Envoy::Matcher::ActionFactory<TransformationContext> {
+public:
+  Envoy::Matcher::ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& config, TransformationContext& context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  std::string name() const override { return "envoy.filters.transformation.action"; }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<envoy::api::v2::filter::http::TransformationRule_Transformations>();
+  }
+};
+
+Envoy::Matcher::ActionFactoryCb
+ActionFactory::createActionFactoryCb(const Protobuf::Message& config, TransformationContext& context,
+                                     ProtobufMessage::ValidationVisitor& validation_visitor) {
+  const auto& action_config =
+      MessageUtil::downcastAndValidate<const envoy::api::v2::filter::http::TransformationRule_Transformations&>(config,
+                                                                               validation_visitor);
+TransformerPairConstSharedPtr transformations = createTransformations(action_config, context.factory_context);
+
+  return [transformations]() { return std::make_unique<TransformationAction>(transformations); };
+}
+
+REGISTER_FACTORY(ActionFactory, Envoy::Matcher::ActionFactory<TransformationContext>);
+
+
+class TransformationValidationVisitor
+    : public Matcher::MatchTreeValidationVisitor<Http::HttpMatchingData> {
+public:
+  absl::Status performDataInputValidation(const Matcher::DataInputFactory<Http::HttpMatchingData>&,
+                                          absl::string_view) override {
+    return absl::OkStatus();
+  }
+};
+
+Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> createTransformationMatcher(
+    const xds::type::matcher::v3::Matcher &matcher_config,
+    Server::Configuration::ServerFactoryContext &factory_context) {
+
+  TransformationContext context{factory_context};
+  TransformationValidationVisitor validation_visitor;
+  Envoy::Matcher::MatchTreeFactory<Http::HttpMatchingData, TransformationContext> factory(
+      context, factory_context, validation_visitor);
+  auto matcher = factory.create(matcher_config)();
+
+  if (!validation_visitor.errors().empty()) {
+    throw EnvoyException(fmt::format("error creating transformation: {}",
+                                     validation_visitor.errors()[0]));
+  }
+  return matcher;
+}
+
+}  // namespace Transformation
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/source/extensions/filters/http/transformation/matcher.cc
+++ b/source/extensions/filters/http/transformation/matcher.cc
@@ -20,7 +20,7 @@ private:
   TransformerPairConstSharedPtr transformations_;
 };
 
-TransformerPairConstSharedPtr matchTransform(Http::Matching::HttpMatchingDataImpl&& data, const Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData>& matcher) {
+TransformerPairConstSharedPtr matchTransform(Http::Matching::SoloHttpMatchingDataImpl&& data, const Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData>& matcher) {
     auto match = Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher, data);
     if (match.result_) {
       auto action = match.result_();

--- a/source/extensions/filters/http/transformation/matcher.h
+++ b/source/extensions/filters/http/transformation/matcher.h
@@ -7,12 +7,14 @@
 #include "source/extensions/filters/http/transformation/transformer.h"
 #include "envoy/server/factory_context.h"
 
+#include "source/common/matcher/data_impl.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Transformation {
 
-TransformerPairConstSharedPtr matchTransform(Http::Matching::HttpMatchingDataImpl&& data, const Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData>& matcher);
+TransformerPairConstSharedPtr matchTransform(Http::Matching::SoloHttpMatchingDataImpl&& data, const Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData>& matcher);
 
 Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> createTransformationMatcher(
     const xds::type::matcher::v3::Matcher &matcher,

--- a/source/extensions/filters/http/transformation/matcher.h
+++ b/source/extensions/filters/http/transformation/matcher.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+#include "source/common/http/matching/data_impl.h"
+#include "envoy/matcher/matcher.h"
+#include "source/extensions/filters/http/transformation/transformer.h"
+#include "envoy/server/factory_context.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+TransformerPairConstSharedPtr matchTransform(Http::Matching::HttpMatchingDataImpl&& data, const Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData>& matcher);
+
+Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> createTransformationMatcher(
+    const xds::type::matcher::v3::Matcher &matcher,
+    Server::Configuration::ServerFactoryContext &factory_context);
+
+} // namespace Transformation
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/transformation/transformation_factory.cc
+++ b/source/extensions/filters/http/transformation/transformation_factory.cc
@@ -1,0 +1,81 @@
+#include "api/envoy/config/filter/http/transformation/v2/transformation_filter.pb.validate.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
+#include "source/extensions/filters/http/transformation/body_header_transformer.h"
+#include "source/extensions/filters/http/transformation/inja_transformer.h"
+#include "source/common/config/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+TransformerConstSharedPtr Transformation::getTransformer(
+    const envoy::api::v2::filter::http::Transformation &transformation,
+    Server::Configuration::CommonFactoryContext &context) {
+  switch (transformation.transformation_type_case()) {
+  case envoy::api::v2::filter::http::Transformation::kTransformationTemplate:
+    return std::make_unique<InjaTransformer>(
+        transformation.transformation_template(), context.api().randomGenerator(), transformation.log_request_response_info(), context.threadLocal());
+  case envoy::api::v2::filter::http::Transformation::kHeaderBodyTransform: {
+    const auto& header_body_transform = transformation.header_body_transform();
+    return std::make_unique<BodyHeaderTransformer>(header_body_transform.add_request_metadata(), transformation.log_request_response_info());
+  }
+  case envoy::api::v2::filter::http::Transformation::kTransformerConfig: {
+    auto &factory = Config::Utility::getAndCheckFactory<TransformerExtensionFactory>(transformation.transformer_config());
+    auto config = Config::Utility::translateAnyToFactoryConfig(transformation.transformer_config().typed_config(), context.messageValidationContext().staticValidationVisitor(), factory);
+    return factory.createTransformer(*config, transformation.log_request_response_info(), context);
+  }
+  case envoy::api::v2::filter::http::Transformation::
+      TRANSFORMATION_TYPE_NOT_SET:
+    ENVOY_LOG(trace, "Request transformation type not set");
+    FALLTHRU;
+  default:
+    throw EnvoyException("non existent transformation");
+  }
+}
+
+std::unique_ptr<const TransformerPair> createTransformations(const envoy::api::v2::filter::http::TransformationRule_Transformations& route_transformation,
+    Server::Configuration::CommonFactoryContext &context) {
+    bool clear_route_cache = route_transformation.clear_route_cache();
+    TransformerConstSharedPtr request_transformation;
+    TransformerConstSharedPtr response_transformation;
+    TransformerConstSharedPtr on_stream_completion_transformation;
+    if (route_transformation.has_request_transformation()) {
+      try {
+        request_transformation = Transformation::getTransformer(
+            route_transformation.request_transformation(), context);
+      } catch (const std::exception &e) {
+        throw EnvoyException(
+            fmt::format("Failed to parse request template: {}", e.what()));
+      }
+    }
+    if (route_transformation.has_response_transformation()) {
+      try {
+        response_transformation = Transformation::getTransformer(
+            route_transformation.response_transformation(), context);
+      } catch (const std::exception &e) {
+        throw EnvoyException(
+            fmt::format("Failed to parse response template: {}", e.what()));
+      }
+    }
+    if (route_transformation.has_on_stream_completion_transformation()) {
+      try {
+        on_stream_completion_transformation = Transformation::getTransformer(
+            route_transformation.on_stream_completion_transformation(),
+            context);
+      } catch (const std::exception &e) {
+        throw EnvoyException(fmt::format(
+            "Failed to get the on stream completion transformation: {}",
+            e.what()));
+      }
+    }
+    return std::make_unique<TransformerPair>(
+          request_transformation, response_transformation,
+          on_stream_completion_transformation, clear_route_cache);
+}
+
+
+}  // namespace Transformation
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/source/extensions/filters/http/transformation/transformation_factory.cc
+++ b/source/extensions/filters/http/transformation/transformation_factory.cc
@@ -15,7 +15,7 @@ TransformerConstSharedPtr Transformation::getTransformer(
   switch (transformation.transformation_type_case()) {
   case envoy::api::v2::filter::http::Transformation::kTransformationTemplate:
     return std::make_unique<InjaTransformer>(
-        transformation.transformation_template(), context.api().randomGenerator(), transformation.log_request_response_info(), context.threadLocal());
+        transformation.transformation_template(), context.api().randomGenerator(), transformation.log_request_response_info());
   case envoy::api::v2::filter::http::Transformation::kHeaderBodyTransform: {
     const auto& header_body_transform = transformation.header_body_transform();
     return std::make_unique<BodyHeaderTransformer>(header_body_transform.add_request_metadata(), transformation.log_request_response_info());

--- a/source/extensions/filters/http/transformation/transformation_factory.h
+++ b/source/extensions/filters/http/transformation/transformation_factory.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/matcher/matcher.h"
+#include "source/extensions/filters/http/transformation/transformer.h"
+#include "envoy/server/factory_context.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+class Transformation : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
+public:
+  static TransformerConstSharedPtr getTransformer(
+      const envoy::api::v2::filter::http::Transformation &transformation,
+      Server::Configuration::CommonFactoryContext &context );
+};
+
+/**
+ * Implemented for transformation extensions and registered via Registry::registerFactory or the
+ * convenience class RegisterFactory.
+ */
+class TransformerExtensionFactory :  public Config::TypedFactory {
+public:
+  ~TransformerExtensionFactory() override = default;
+
+/**
+ * Create a particular transformation extension implementation from a config proto. If the
+ * implementation is unable to produce a factory with the provided parameters, it should throw
+ * EnvoyException. The returned pointer should never be nullptr.
+ * @param config the custom configuration for this transformer extension type.
+ */
+  virtual TransformerConstSharedPtr createTransformer(const Protobuf::Message &config,
+    google::protobuf::BoolValue log_request_response_info,
+    Server::Configuration::CommonFactoryContext &context) PURE;
+
+  virtual std::string name() const override PURE;
+
+  std::string category() const override {return "io.solo.transformer"; }
+};
+
+std::unique_ptr<const TransformerPair> createTransformations(
+    const envoy::api::v2::filter::http::TransformationRule_Transformations& route_transformation,
+    Server::Configuration::CommonFactoryContext &context);
+
+} // namespace Transformation
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -174,7 +174,7 @@ void TransformationFilter::setupTransformationPair() {
       config_to_use = staged_config;
     }
   }
-  active_transformer_pair = config_to_use->findTransformers(*request_headers_);
+  active_transformer_pair = config_to_use->findTransformers(*request_headers_, decoder_callbacks_->streamInfo());
 
   if (active_transformer_pair != nullptr) {
     should_clear_cache_ = active_transformer_pair->shouldClearCache();

--- a/source/extensions/filters/http/transformation/transformation_filter_config.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.cc
@@ -2,13 +2,11 @@
 
 #include "source/common/common/assert.h"
 #include "source/common/common/matchers.h"
-#include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/config/utility.h"
-
-
-#include "source/extensions/filters/http/transformation/body_header_transformer.h"
-#include "source/extensions/filters/http/transformation/inja_transformer.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/filters/http/transformation/matcher.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
+#include "source/common/matcher/matcher.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -38,59 +36,40 @@ TransformerConstSharedPtr Transformation::getTransformer(
   default:
     throw EnvoyException("non existent transformation");
   }
+  
+void TransformationFilterConfig::addTransformationLegacy(
+    const envoy::api::v2::filter::http::TransformationRule &rule,
+    Server::Configuration::FactoryContext &context) {
+  if (!rule.has_match()) {
+    return;
+  }
+  TransformerConstSharedPtr request_transformation;
+  TransformerConstSharedPtr response_transformation;
+  TransformerConstSharedPtr on_stream_completion_transformation;
+  bool clear_route_cache = false;
+
+  TransformerPairConstSharedPtr transformer_pair = 
+      std::make_unique<TransformerPair>(
+          request_transformation, response_transformation,
+          on_stream_completion_transformation, clear_route_cache);
+  if (rule.has_route_transformations()) {
+    transformer_pair = createTransformations(rule.route_transformations(), context);
+  }
+  transformer_pairs_.emplace_back(Matcher::Matcher::create(rule.match()),
+                                  transformer_pair);
 }
 
 TransformationFilterConfig::TransformationFilterConfig(
     const TransformationConfigProto &proto_config, const std::string &prefix,
     Server::Configuration::FactoryContext &context)
-    : FilterConfig(prefix, context.scope(), proto_config.stage(), proto_config.log_request_response_info()) {
-
+    : FilterConfig(prefix, context.scope(), proto_config.stage(),
+                   proto_config.log_request_response_info()) {
+    if (proto_config.has_matcher()) {
+      matcher_ = createTransformationMatcher(proto_config.matcher(), context.getServerFactoryContext());
+      return;
+    }
   for (const auto &rule : proto_config.transformations()) {
-    if (!rule.has_match()) {
-      continue;
-    }
-    TransformerConstSharedPtr request_transformation;
-    TransformerConstSharedPtr response_transformation;
-    TransformerConstSharedPtr on_stream_completion_transformation;
-    bool clear_route_cache = false;
-    if (rule.has_route_transformations()) {
-      const auto &route_transformation = rule.route_transformations();
-      clear_route_cache = route_transformation.clear_route_cache();
-      if (route_transformation.has_request_transformation()) {
-        try {
-          request_transformation = Transformation::getTransformer(
-              route_transformation.request_transformation(), context);
-        } catch (const std::exception &e) {
-          throw EnvoyException(
-              fmt::format("Failed to parse request template: {}", e.what()));
-        }
-      }
-      if (route_transformation.has_response_transformation()) {
-        try {
-          response_transformation = Transformation::getTransformer(
-              route_transformation.response_transformation(), context);
-        } catch (const std::exception &e) {
-          throw EnvoyException(
-              fmt::format("Failed to parse response template: {}", e.what()));
-        }
-      }
-      if (route_transformation.has_on_stream_completion_transformation()) {
-        try {
-          on_stream_completion_transformation = Transformation::getTransformer(
-              route_transformation.on_stream_completion_transformation(), context);
-        } catch (const std::exception &e) {
-          throw EnvoyException(
-              fmt::format("Failed to get the on stream completion transformation: {}", e.what()));
-        }
-      }
-    }
-    TransformerPairConstSharedPtr transformer_pair =
-        std::make_unique<TransformerPair>(request_transformation,
-                                          response_transformation,
-                                          on_stream_completion_transformation,
-                                          clear_route_cache);
-    transformer_pairs_.emplace_back(Matcher::Matcher::create(rule.match()),
-                                    transformer_pair);
+      addTransformationLegacy(rule, context);
   }
 }
 
@@ -168,11 +147,23 @@ RouteTransformationFilterConfig::RouteTransformationFilterConfig(
       temp_stages[transformation.stage()].reset(
           new PerStageRouteTransformationFilterConfig());
     }
-    temp_stages[transformation.stage()]->addTransformation(transformation, context);
+
+    if (transformation.has_matcher()) {
+      temp_stages[transformation.stage()]->setMatcher(createTransformationMatcher(transformation.matcher(), context));
+    } else {
+      temp_stages[transformation.stage()]->addTransformation(transformation, context);
+    }
   }
   for (uint32_t i = 0; i < stages_.size(); i++) {
     stages_[i] = std::move(temp_stages[i]);
   }
+}
+
+void PerStageRouteTransformationFilterConfig::setMatcher(Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher){
+  if (matcher_ != nullptr){
+    throw EnvoyException(fmt::format("Only one matcher is allowed per stage"));
+  }
+  matcher_ = matcher;
 }
 
 void PerStageRouteTransformationFilterConfig::addTransformation(
@@ -213,7 +204,6 @@ void PerStageRouteTransformationFilterConfig::addTransformation(
 
     if (request_transformation != nullptr ||
         response_transformation != nullptr) {
-
       TransformerPairConstSharedPtr transformer_pair =
           std::make_unique<TransformerPair>(request_transformation,
                                             response_transformation,
@@ -250,7 +240,14 @@ void PerStageRouteTransformationFilterConfig::addTransformation(
 
 TransformerPairConstSharedPtr
 PerStageRouteTransformationFilterConfig::findTransformers(
-    const Http::RequestHeaderMap &headers) const {
+    const Http::RequestHeaderMap &headers, StreamInfo::StreamInfo& info) const {
+
+  if (matcher_) {
+      Http::Matching::HttpMatchingDataImpl data(info);
+      data.onRequestHeaders(headers);
+      return matchTransform(std::move(data), matcher_); 
+  }
+
   for (const auto &pair : transformer_pairs_) {
     if (pair.matcher() == nullptr || pair.matcher()->matches(headers)) {
       return pair.transformer_pair();

--- a/source/extensions/filters/http/transformation/transformation_filter_config.h
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.h
@@ -12,6 +12,8 @@
 #include "api/envoy/config/filter/http/transformation/v2/transformation_filter.pb.validate.h"
 #include "envoy/server/factory_context.h"
 
+#include "source/common/matcher/data_impl.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {

--- a/source/extensions/filters/http/transformation/transformer.h
+++ b/source/extensions/filters/http/transformation/transformer.h
@@ -6,36 +6,13 @@
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 #include "envoy/router/router.h"
-#include "envoy/stats/scope.h"
-#include "envoy/stats/stats_macros.h"
 
-#include "source/common/http/header_utility.h"
-#include "source/common/matcher/solo_matcher.h"
 #include "source/common/protobuf/protobuf.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Transformation {
-
-/**
- * All stats for the transformation filter. @see stats_macros.h
- */
-#define ALL_TRANSFORMATION_FILTER_STATS(COUNTER)                               \
-  COUNTER(request_body_transformations)                                        \
-  COUNTER(request_header_transformations)                                      \
-  COUNTER(response_header_transformations)                                     \
-  COUNTER(response_body_transformations)                                       \
-  COUNTER(request_error)                                                       \
-  COUNTER(response_error)                                                      \
-  COUNTER(on_stream_complete_error)
-
-/**
- * Wrapper struct for transformation @see stats_macros.h
- */
-struct TransformationFilterStats {
-  ALL_TRANSFORMATION_FILTER_STATS(GENERATE_COUNTER_STRUCT)
-};
 
 class Transformer {
 public:
@@ -53,6 +30,7 @@ public:
 
   google::protobuf::BoolValue logRequestResponseInfo() const { return log_request_response_info_; }
 
+private:
   google::protobuf::BoolValue log_request_response_info_{};
 };
 
@@ -63,7 +41,11 @@ public:
   TransformerPair(TransformerConstSharedPtr request_transformer,
                   TransformerConstSharedPtr response_transformer,
                   TransformerConstSharedPtr on_stream_completion_transformer,
-                  bool should_clear_cache);
+                  bool should_clear_cache)
+    : clear_route_cache_(should_clear_cache),
+      request_transformation_(request_transformer),
+      response_transformation_(response_transformer),
+      on_stream_completion_transformation_(on_stream_completion_transformer) {}
 
   TransformerConstSharedPtr getRequestTranformation() const {
     return request_transformation_;
@@ -86,90 +68,6 @@ private:
   TransformerConstSharedPtr on_stream_completion_transformation_;
 };
 typedef std::shared_ptr<const TransformerPair> TransformerPairConstSharedPtr;
-
-class TransformConfig {
-public:
-  virtual ~TransformConfig() {}
-  virtual TransformerPairConstSharedPtr
-  findTransformers(const Http::RequestHeaderMap &headers) const PURE;
-  virtual TransformerConstSharedPtr
-  findResponseTransform(const Http::ResponseHeaderMap &headers,
-                        StreamInfo::StreamInfo &) const PURE;
-};
-
-class StagedTransformConfig {
-public:
-  virtual ~StagedTransformConfig() {}
-  virtual const TransformConfig *
-  transformConfigForStage(uint32_t stage) const PURE;
-};
-
-class MatcherTransformerPair {
-public:
-  MatcherTransformerPair(Matcher::MatcherConstPtr matcher,
-                         TransformerPairConstSharedPtr transformer_pair)
-      : matcher_(matcher), transformer_pair_(transformer_pair) {}
-
-  TransformerPairConstSharedPtr transformer_pair() const {
-    return transformer_pair_;
-  }
-
-  Matcher::MatcherConstPtr matcher() const { return matcher_; }
-
-private:
-  Matcher::MatcherConstPtr matcher_;
-  TransformerPairConstSharedPtr transformer_pair_;
-};
-
-class FilterConfig : public TransformConfig {
-public:
-  FilterConfig(const std::string &prefix, Stats::Scope &scope, uint32_t stage, bool log_request_response_info)
-      : stats_(generateStats(prefix, scope)), stage_(stage), log_request_response_info_(log_request_response_info) {}
-
-  static TransformationFilterStats generateStats(const std::string &prefix,
-                                                 Stats::Scope &scope);
-
-  virtual const std::vector<MatcherTransformerPair> &
-  transformerPairs() const PURE;
-
-  // Finds the matcher that matched the header
-  TransformerPairConstSharedPtr
-  findTransformers(const Http::RequestHeaderMap &headers) const override;
-
-  TransformerConstSharedPtr
-  findResponseTransform(const Http::ResponseHeaderMap &,
-                        StreamInfo::StreamInfo &) const override {
-    return nullptr;
-  }
-
-  TransformationFilterStats &stats() { return stats_; }
-
-  virtual std::string name() const PURE;
-
-  uint32_t stage() const { return stage_; }
-
-  bool logRequestResponseInfo() const { return log_request_response_info_; }
-
-private:
-  TransformationFilterStats stats_;
-  uint32_t stage_{};
-  bool log_request_response_info_{};
-};
-
-class RouteFilterConfig : public Router::RouteSpecificFilterConfig,
-                          public StagedTransformConfig {
-public:
-  RouteFilterConfig();
-
-  const TransformConfig *transformConfigForStage(uint32_t stage) const override;
-
-protected:
-  std::vector<std::unique_ptr<const TransformConfig>> stages_;
-};
-
-typedef std::shared_ptr<const RouteFilterConfig>
-    RouteFilterConfigConstSharedPtr;
-typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
 
 } // namespace Transformation
 } // namespace HttpFilters

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
@@ -6,6 +6,7 @@
 #include "nlohmann/json.hpp"
 
 #include "source/extensions/filters/http/transformation/transformation_filter_config.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
 #include "api/envoy/config/transformer/aws_lambda/v2/api_gateway_transformer.pb.h"
 #include "api/envoy/config/transformer/aws_lambda/v2/api_gateway_transformer.pb.validate.h"
 

--- a/test/extensions/filters/http/aws_lambda/test_transformer.h
+++ b/test/extensions/filters/http/aws_lambda/test_transformer.h
@@ -1,4 +1,5 @@
 #include "source/extensions/filters/http/transformation/transformation_filter_config.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
 #include "test/extensions/filters/http/aws_lambda/api_gateway_test_transformer.pb.h"
 
 namespace Envoy {

--- a/test/extensions/filters/http/transformation/BUILD
+++ b/test/extensions/filters/http/transformation/BUILD
@@ -64,7 +64,7 @@ envoy_gloo_cc_test(
     repository = "@envoy",
     deps = [
         "//source/extensions/filters/http/transformation:matcher_lib",
-        "//source/common/matcher:matchers_data_impl_lib",
+        "//source/common/matcher:solo_matcher_data_impl_lib",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/mocks/stream_info:stream_info_mocks",
         "@envoy//source/common/http/matching:inputs_lib",

--- a/test/extensions/filters/http/transformation/BUILD
+++ b/test/extensions/filters/http/transformation/BUILD
@@ -64,6 +64,7 @@ envoy_gloo_cc_test(
     repository = "@envoy",
     deps = [
         "//source/extensions/filters/http/transformation:matcher_lib",
+        "//source/common/matcher:matchers_data_impl_lib",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/mocks/stream_info:stream_info_mocks",
         "@envoy//source/common/http/matching:inputs_lib",

--- a/test/extensions/filters/http/transformation/BUILD
+++ b/test/extensions/filters/http/transformation/BUILD
@@ -54,6 +54,19 @@ envoy_gloo_cc_test(
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/mocks/upstream:upstream_mocks",
         "@envoy//test/common/common:logger_test",
+        "@envoy//source/common/http/matching:inputs_lib",
+    ],
+)
+
+envoy_gloo_cc_test(
+    name = "matcher_test",
+    srcs = ["matcher_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/extensions/filters/http/transformation:matcher_lib",
+        "@envoy//test/mocks/server:server_mocks",
+        "@envoy//test/mocks/stream_info:stream_info_mocks",
+        "@envoy//source/common/http/matching:inputs_lib",
     ],
 )
 

--- a/test/extensions/filters/http/transformation/fake_transformer.h
+++ b/test/extensions/filters/http/transformation/fake_transformer.h
@@ -1,4 +1,5 @@
 #include "source/extensions/filters/http/transformation/transformation_filter_config.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
 #include "test/extensions/filters/http/transformation/fake_transformer.pb.h"
 
 namespace Envoy {

--- a/test/extensions/filters/http/transformation/matcher_test.cc
+++ b/test/extensions/filters/http/transformation/matcher_test.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/http/transformation/matcher.h"
 
+#include "source/common/matcher/data_impl.h"
+
 #include "fmt/format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -32,7 +34,7 @@ TransformerPairConstSharedPtr getFromMatcher(std::string s){
 
   auto m = createTransformationMatcher(matcher, server_factory_context);
 
-  Http::Matching::HttpMatchingDataImpl data(stream_info);
+  Http::Matching::SoloHttpMatchingDataImpl data(stream_info);
 
   Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":authority", "www.solo.io"}, {":path", "/path"}};

--- a/test/extensions/filters/http/transformation/matcher_test.cc
+++ b/test/extensions/filters/http/transformation/matcher_test.cc
@@ -1,0 +1,217 @@
+#include "source/extensions/filters/http/transformation/matcher.h"
+
+#include "fmt/format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test/mocks/server/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
+#include "test/test_common/utility.h"
+
+using testing::_;
+using testing::AtLeast;
+using testing::Invoke;
+using testing::Return;
+using testing::ReturnPointee;
+using testing::ReturnRef;
+using testing::SaveArg;
+using testing::Throw;
+using testing::WithArg;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+TransformerPairConstSharedPtr getFromMatcher(std::string s){
+  NiceMock<Server::Configuration::MockServerFactoryContext>
+      server_factory_context;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
+  xds::type::matcher::v3::Matcher matcher;
+  TestUtility::loadFromYaml(s, matcher);
+
+  auto m = createTransformationMatcher(matcher, server_factory_context);
+
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "GET"}, {":authority", "www.solo.io"}, {":path", "/path"}};
+  data.onRequestHeaders(headers);
+  return matchTransform(std::move(data), m);
+}
+
+TEST(TransformationMatcher, TestGetRequestTransformer) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              request_transformation:
+                transformation_template:
+                  passthrough: {}
+                  headers:
+                    "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_NE(t->getRequestTranformation(), nullptr);
+  EXPECT_EQ(t->getResponseTranformation(), nullptr);
+  EXPECT_EQ(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), false);
+}
+
+TEST(TransformationMatcher, TestGetRequestTransformerClearCache) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              clear_route_cache: true
+              request_transformation:
+                transformation_template:
+                  passthrough: {}
+                  headers:
+                    "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_NE(t->getRequestTranformation(), nullptr);
+  EXPECT_EQ(t->getResponseTranformation(), nullptr);
+  EXPECT_EQ(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), true);
+}
+
+TEST(TransformationMatcher, TestGetResponseTransformer) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              response_transformation:
+                 transformation_template:
+                   passthrough: {}
+                   headers:
+                     "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_EQ(t->getRequestTranformation(), nullptr);
+  EXPECT_NE(t->getResponseTranformation(), nullptr);
+  EXPECT_EQ(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), false);
+}
+
+TEST(TransformationMatcher, TestGetStreamCompleteTransformer) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              on_stream_completion_transformation:
+                 transformation_template:
+                   passthrough: {}
+                   headers:
+                     "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_EQ(t->getRequestTranformation(), nullptr);
+  EXPECT_EQ(t->getResponseTranformation(), nullptr);
+  EXPECT_NE(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), false);
+}
+
+TEST(TransformationMatcher, TestGetTransformOnNonMatch) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/prefix_no_exists"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              on_stream_completion_transformation:
+                transformation_template:
+                  passthrough: {}
+                  headers:
+                    "x-foo": {text: "matcher"}
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+          request_transformation:
+             transformation_template:
+               passthrough: {}
+               headers:
+                 "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_NE(t->getRequestTranformation(), nullptr);
+  EXPECT_EQ(t->getResponseTranformation(), nullptr);
+  EXPECT_EQ(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), false);
+}
+
+}  // namespace Transformation
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/test/extensions/filters/http/transformation/transformation_filter_config_test.cc
+++ b/test/extensions/filters/http/transformation/transformation_filter_config_test.cc
@@ -28,7 +28,7 @@ namespace Transformation {
 using FakeTransformerProto = envoy::test::extensions::transformation::FakeTransformer;
 
 
-TEST(TransformerExtensionFactory, TestTransformerExtensionFactoryRegistration){
+TEST(TransformerExtensionFactory, TestTransformerExtensionFactoryRegistration) {
   envoy::api::v2::filter::http::Transformation transformation;
   auto factoryConfig = transformation.mutable_transformer_config();
   factoryConfig->set_name("io.solo.transformer.fake");
@@ -38,7 +38,7 @@ TEST(TransformerExtensionFactory, TestTransformerExtensionFactoryRegistration){
   EXPECT_EQ(factory.name(), "io.solo.transformer.fake");
 }
 
-TEST(Transformation, TestGetTransformer){
+TEST(Transformation, TestGetTransformer) {
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
 
   Transformation t;


### PR DESCRIPTION
# Description
 - Backport #274 to v1.25
 - This adds support for using unified matcher API to the transformation filter.