### PR TITLE
[v1.25] Backport Unified Matcher Support, using bazel patches

### DIFF
--- a/api/envoy/config/filter/http/transformation/v2/BUILD
+++ b/api/envoy/config/filter/http/transformation/v2/BUILD
@@ -16,6 +16,7 @@ api_proto_package(
         "@envoy_api//envoy/type:pkg",
         "@envoy_api//envoy/type/matcher/v3:pkg",
         "@envoy_api//envoy/type/matcher:pkg",
+        "@com_github_cncf_udpa//xds/type/matcher/v3:pkg",
     ],
     visibility = ["//visibility:public"],
 )

--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -11,6 +11,7 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 import "validate/validate.proto";
 
+import "xds/type/matcher/v3/matcher.proto";
 import "envoy/config/route/v3/route_components.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "envoy/config/core/v3/extension.proto";
@@ -20,6 +21,9 @@ message FilterTransformations {
   // transformation will be applied. If there are overlapped match conditions,
   // please put the most specific match first.
   repeated TransformationRule transformations = 1;
+
+  // If provided, transformations fields here are ignored. The transformation will be the action from this matcher.
+  xds.type.matcher.v3.Matcher matcher = 4;
 
   // Only RouteTransformations.RouteTransformation with matching stage will be
   // used with this filter.
@@ -96,9 +100,13 @@ message RouteTransformations {
       RequestMatch request_match = 2;
       ResponseMatch response_match = 3;
     }
+    // If provided, transformations with request_match in transformations field are ignored.
+    // The transformation will be the action from this matcher.
+    xds.type.matcher.v3.Matcher matcher = 5;
   }
 
   repeated RouteTransformation transformations = 4;
+
 }
 
 message ResponseMatcher {

--- a/bazel/foreign_cc/matcher-updates-25.patch
+++ b/bazel/foreign_cc/matcher-updates-25.patch
@@ -1,0 +1,791 @@
+diff --git a/envoy/http/filter.h b/envoy/http/filter.h
+index 9741a896e9..3efdf9ae15 100644
+--- envoy/http/filter.h
++++ envoy/http/filter.h
+@@ -1110,6 +1110,7 @@ public:
+   virtual RequestTrailerMapOptConstRef requestTrailers() const PURE;
+   virtual ResponseHeaderMapOptConstRef responseHeaders() const PURE;
+   virtual ResponseTrailerMapOptConstRef responseTrailers() const PURE;
++  virtual const StreamInfo::StreamInfo& streamInfo() const PURE;
+   virtual const Network::ConnectionInfoProvider& connectionInfoProvider() const PURE;
+ 
+   const Network::Address::Instance& localAddress() const {
+diff --git a/source/common/http/match_delegate/config.h b/source/common/http/match_delegate/config.h
+index 48a63c9a2c..3e36c59572 100644
+--- source/common/http/match_delegate/config.h
++++ source/common/http/match_delegate/config.h
+@@ -30,8 +30,7 @@ public:
+     bool skipFilter() const { return skip_filter_; }
+     void onStreamInfo(const StreamInfo::StreamInfo& stream_info) {
+       if (has_match_tree_ && matching_data_ == nullptr) {
+-        matching_data_ = std::make_shared<Envoy::Http::Matching::HttpMatchingDataImpl>(
+-            stream_info.downstreamAddressProvider());
++        matching_data_ = std::make_shared<Envoy::Http::Matching::HttpMatchingDataImpl>(stream_info);
+       }
+     }
+     void setBaseFilter(Envoy::Http::StreamFilterBase* base_filter) { base_filter_ = base_filter; }
+diff --git a/source/common/http/matching/data_impl.h b/source/common/http/matching/data_impl.h
+index 6a8f1d9c59..ded401d855 100644
+--- source/common/http/matching/data_impl.h
++++ source/common/http/matching/data_impl.h
+@@ -13,8 +13,8 @@ namespace Matching {
+  */
+ class HttpMatchingDataImpl : public HttpMatchingData {
+ public:
+-  explicit HttpMatchingDataImpl(const Network::ConnectionInfoProvider& connection_info_provider)
+-      : connection_info_provider_(connection_info_provider) {}
++  explicit HttpMatchingDataImpl(const StreamInfo::StreamInfo& stream_info)
++      : stream_info_(stream_info) {}
+ 
+   static absl::string_view name() { return "http"; }
+ 
+@@ -50,12 +50,14 @@ public:
+     return makeOptRefFromPtr(response_trailers_);
+   }
+ 
++  const StreamInfo::StreamInfo& streamInfo() const override { return stream_info_; }
++
+   const Network::ConnectionInfoProvider& connectionInfoProvider() const override {
+-    return connection_info_provider_;
++    return stream_info_.downstreamAddressProvider();
+   }
+ 
+ private:
+-  const Network::ConnectionInfoProvider& connection_info_provider_;
++  const StreamInfo::StreamInfo& stream_info_;
+   const RequestHeaderMap* request_headers_{};
+   const ResponseHeaderMap* response_headers_{};
+   const RequestTrailerMap* request_trailers_{};
+diff --git a/source/common/router/config_impl.cc b/source/common/router/config_impl.cc
+index 93eacd1eaf..1c75a39c46 100644
+--- source/common/router/config_impl.cc
++++ source/common/router/config_impl.cc
+@@ -1960,7 +1960,7 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const RouteCallback& cb
+   }
+ 
+   if (matcher_) {
+-    Http::Matching::HttpMatchingDataImpl data(stream_info.downstreamAddressProvider());
++    Http::Matching::HttpMatchingDataImpl data(stream_info);
+     data.onRequestHeaders(headers);
+ 
+     auto match = Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);
+diff --git a/source/common/router/router_ratelimit.cc b/source/common/router/router_ratelimit.cc
+index 4727d5f693..5a9addb1c7 100644
+--- source/common/router/router_ratelimit.cc
++++ source/common/router/router_ratelimit.cc
+@@ -58,7 +58,7 @@ public:
+   bool populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry, const std::string&,
+                           const Http::RequestHeaderMap& headers,
+                           const StreamInfo::StreamInfo& info) const override {
+-    Http::Matching::HttpMatchingDataImpl data(info.downstreamAddressProvider());
++    Http::Matching::HttpMatchingDataImpl data(info);
+     data.onRequestHeaders(headers);
+     auto result = data_input_->get(data);
+     if (result.data_) {
+diff --git a/source/extensions/filters/common/rbac/engine_impl.cc b/source/extensions/filters/common/rbac/engine_impl.cc
+index 33ef236939..76d010c562 100644
+--- source/extensions/filters/common/rbac/engine_impl.cc
++++ source/extensions/filters/common/rbac/engine_impl.cc
+@@ -129,9 +129,9 @@ bool RoleBasedAccessControlMatcherEngineImpl::handleAction(const Network::Connec
+ }
+ 
+ bool RoleBasedAccessControlMatcherEngineImpl::handleAction(
+-    const Network::Connection& connection, const Envoy::Http::RequestHeaderMap& headers,
++    const Network::Connection&, const Envoy::Http::RequestHeaderMap& headers,
+     StreamInfo::StreamInfo& info, std::string* effective_policy_id) const {
+-  Http::Matching::HttpMatchingDataImpl data(connection.connectionInfoProvider());
++  Http::Matching::HttpMatchingDataImpl data(info);
+   data.onRequestHeaders(headers);
+   const auto& result = Envoy::Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher_, data);
+   ASSERT(result.match_state_ == Envoy::Matcher::MatchState::MatchComplete);
+diff --git a/source/extensions/filters/http/custom_response/config.cc b/source/extensions/filters/http/custom_response/config.cc
+index f186ee5c5b..472cf5c085 100644
+--- source/extensions/filters/http/custom_response/config.cc
++++ source/extensions/filters/http/custom_response/config.cc
+@@ -55,7 +55,7 @@ PolicySharedPtr FilterConfig::getPolicy(::Envoy::Http::ResponseHeaderMap& header
+     return PolicySharedPtr{};
+   }
+ 
+-  ::Envoy::Http::Matching::HttpMatchingDataImpl data(stream_info.downstreamAddressProvider());
++  ::Envoy::Http::Matching::HttpMatchingDataImpl data(stream_info);
+   data.onResponseHeaders(headers);
+   auto match = Matcher::evaluateMatch<::Envoy::Http::HttpMatchingData>(*matcher_, data);
+   if (!match.result_) {
+diff --git a/source/extensions/filters/http/rate_limit_quota/filter.cc b/source/extensions/filters/http/rate_limit_quota/filter.cc
+index 2b6797bc27..95b37d4ede 100644
+--- source/extensions/filters/http/rate_limit_quota/filter.cc
++++ source/extensions/filters/http/rate_limit_quota/filter.cc
+@@ -42,8 +42,7 @@ RateLimitQuotaFilter::requestMatching(const Http::RequestHeaderMap& headers) {
+   // This avoids creating the data object for every request, which is expensive.
+   if (data_ptr_ == nullptr) {
+     if (callbacks_ != nullptr) {
+-      data_ptr_ = std::make_unique<Http::Matching::HttpMatchingDataImpl>(
+-          callbacks_->streamInfo().downstreamAddressProvider());
++      data_ptr_ = std::make_unique<Http::Matching::HttpMatchingDataImpl>(callbacks_->streamInfo());
+     } else {
+       return absl::InternalError("Filter callback has not been initialized successfully yet.");
+     }
+diff --git a/test/common/http/matching/BUILD b/test/common/http/matching/BUILD
+index dc47734aa9..1dbd3cfa1c 100644
+--- test/common/http/matching/BUILD
++++ test/common/http/matching/BUILD
+@@ -16,6 +16,7 @@ envoy_cc_test(
+         "//source/common/http/matching:inputs_lib",
+         "//source/common/network:address_lib",
+         "//source/common/network:socket_lib",
++        "//test/test_common:test_time_lib",
+     ],
+ )
+ 
+@@ -27,5 +28,6 @@ envoy_cc_test(
+         "//source/common/http/matching:status_code_input_lib",
+         "//source/common/network:address_lib",
+         "//source/common/network:socket_lib",
++        "//test/test_common:test_time_lib",
+     ],
+ )
+diff --git a/test/common/http/matching/inputs_test.cc b/test/common/http/matching/inputs_test.cc
+index d90924dd14..9905b3a101 100644
+--- test/common/http/matching/inputs_test.cc
++++ test/common/http/matching/inputs_test.cc
+@@ -1,22 +1,37 @@
++#include <memory>
++
+ #include "envoy/http/filter.h"
+ 
+ #include "source/common/http/matching/data_impl.h"
+ #include "source/common/http/matching/inputs.h"
+ #include "source/common/network/address_impl.h"
+ #include "source/common/network/socket_impl.h"
++#include "source/common/stream_info/stream_info_impl.h"
+ 
++#include "test/test_common/test_time.h"
+ #include "test/test_common/utility.h"
+ 
+ namespace Envoy {
+ namespace Http {
+ namespace Matching {
+ 
++std::shared_ptr<Network::ConnectionInfoSetterImpl> connectionInfoProvider() {
++  CONSTRUCT_ON_FIRST_USE(std::shared_ptr<Network::ConnectionInfoSetterImpl>,
++                         std::make_shared<Network::ConnectionInfoSetterImpl>(
++                             std::make_shared<Network::Address::Ipv4Instance>(80),
++                             std::make_shared<Network::Address::Ipv4Instance>(80)));
++}
++
++StreamInfo::StreamInfoImpl createStreamInfo() {
++  CONSTRUCT_ON_FIRST_USE(StreamInfo::StreamInfoImpl,
++                         StreamInfo::StreamInfoImpl(Http::Protocol::Http2,
++                                                    Event::GlobalTimeSystem().timeSystem(),
++                                                    connectionInfoProvider()));
++}
++
+ TEST(MatchingData, HttpRequestHeadersDataInput) {
+   HttpRequestHeadersDataInput input("header");
+-  Network::ConnectionInfoSetterImpl connection_info_provider(
+-      std::make_shared<Network::Address::Ipv4Instance>(80),
+-      std::make_shared<Network::Address::Ipv4Instance>(80));
+-  HttpMatchingDataImpl data(connection_info_provider);
++  HttpMatchingDataImpl data(createStreamInfo());
+ 
+   {
+     TestRequestHeaderMapImpl request_headers({{"header", "bar"}});
+@@ -37,10 +52,7 @@ TEST(MatchingData, HttpRequestHeadersDataInput) {
+ 
+ TEST(MatchingData, HttpRequestTrailersDataInput) {
+   HttpRequestTrailersDataInput input("header");
+-  Network::ConnectionInfoSetterImpl connection_info_provider(
+-      std::make_shared<Network::Address::Ipv4Instance>(80),
+-      std::make_shared<Network::Address::Ipv4Instance>(80));
+-  HttpMatchingDataImpl data(connection_info_provider);
++  HttpMatchingDataImpl data(createStreamInfo());
+ 
+   {
+     TestRequestTrailerMapImpl request_trailers({{"header", "bar"}});
+@@ -64,7 +76,7 @@ TEST(MatchingData, HttpResponseHeadersDataInput) {
+   Network::ConnectionInfoSetterImpl connection_info_provider(
+       std::make_shared<Network::Address::Ipv4Instance>(80),
+       std::make_shared<Network::Address::Ipv4Instance>(80));
+-  HttpMatchingDataImpl data(connection_info_provider);
++  HttpMatchingDataImpl data(createStreamInfo());
+ 
+   {
+     TestResponseHeaderMapImpl response_headers({{"header", "bar"}});
+@@ -88,7 +100,7 @@ TEST(MatchingData, HttpResponseTrailersDataInput) {
+   Network::ConnectionInfoSetterImpl connection_info_provider(
+       std::make_shared<Network::Address::Ipv4Instance>(80),
+       std::make_shared<Network::Address::Ipv4Instance>(80));
+-  HttpMatchingDataImpl data(connection_info_provider);
++  HttpMatchingDataImpl data(createStreamInfo());
+ 
+   {
+     TestResponseTrailerMapImpl response_trailers({{"header", "bar"}});
+@@ -107,6 +119,61 @@ TEST(MatchingData, HttpResponseTrailersDataInput) {
+   }
+ }
+ 
++TEST(MatchingData, HttpRequestQueryParamsDataInput) {
++  Network::ConnectionInfoSetterImpl connection_info_provider(
++      std::make_shared<Network::Address::Ipv4Instance>(80),
++      std::make_shared<Network::Address::Ipv4Instance>(80));
++  HttpMatchingDataImpl data(createStreamInfo());
++
++  {
++    HttpRequestQueryParamsDataInput input("arg");
++    auto result = input.get(data);
++    EXPECT_EQ(result.data_availability_,
++              Matcher::DataInputGetResult::DataAvailability::NotAvailable);
++    EXPECT_EQ(result.data_, absl::nullopt);
++  }
++
++  {
++    HttpRequestQueryParamsDataInput input("user name");
++    TestRequestHeaderMapImpl request_headers({{":path", "/test?user%20name=foo%20bar"}});
++    data.onRequestHeaders(request_headers);
++
++    EXPECT_EQ(input.get(data).data_, "foo bar");
++  }
++
++  {
++    HttpRequestQueryParamsDataInput input("username");
++    TestRequestHeaderMapImpl request_headers({{":path", "/test?username=fooA&username=fooB"}});
++    data.onRequestHeaders(request_headers);
++
++    EXPECT_EQ(input.get(data).data_, "fooA");
++  }
++
++  {
++    HttpRequestQueryParamsDataInput input("username");
++    TestRequestHeaderMapImpl request_headers({{":path", "/test"}});
++    data.onRequestHeaders(request_headers);
++
++    const auto result = input.get(data);
++
++    EXPECT_EQ(result.data_availability_,
++              Matcher::DataInputGetResult::DataAvailability::AllDataAvailable);
++    EXPECT_EQ(result.data_, absl::nullopt);
++  }
++
++  {
++    HttpRequestQueryParamsDataInput input("username");
++    TestRequestHeaderMapImpl request_headers;
++    data.onRequestHeaders(request_headers);
++
++    const auto result = input.get(data);
++
++    EXPECT_EQ(result.data_availability_,
++              Matcher::DataInputGetResult::DataAvailability::NotAvailable);
++    EXPECT_EQ(result.data_, absl::nullopt);
++  }
++}
++
+ } // namespace Matching
+ } // namespace Http
+ } // namespace Envoy
+diff --git a/test/common/http/matching/status_code_input_test.cc b/test/common/http/matching/status_code_input_test.cc
+index f80aa73b3e..1d81e34b7d 100644
+--- test/common/http/matching/status_code_input_test.cc
++++ test/common/http/matching/status_code_input_test.cc
+@@ -4,19 +4,34 @@
+ #include "source/common/http/matching/status_code_input.h"
+ #include "source/common/network/address_impl.h"
+ #include "source/common/network/socket_impl.h"
++#include "source/common/stream_info/stream_info_impl.h"
+ 
++#include "test/test_common/test_time.h"
+ #include "test/test_common/utility.h"
+ 
+ namespace Envoy {
+ namespace Http {
+ namespace Matching {
+ 
++std::shared_ptr<Network::ConnectionInfoSetterImpl> connectionInfoProvider() {
++  CONSTRUCT_ON_FIRST_USE(std::shared_ptr<Network::ConnectionInfoSetterImpl>,
++                         std::make_shared<Network::ConnectionInfoSetterImpl>(
++                             std::make_shared<Network::Address::Ipv4Instance>(80),
++                             std::make_shared<Network::Address::Ipv4Instance>(80)));
++}
++
++StreamInfo::StreamInfoImpl createStreamInfo() {
++  CONSTRUCT_ON_FIRST_USE(StreamInfo::StreamInfoImpl,
++                         StreamInfo::StreamInfoImpl(Http::Protocol::Http2,
++                                                    Event::GlobalTimeSystem().timeSystem(),
++                                                    connectionInfoProvider()));
++}
+ TEST(MatchingData, HttpResponseStatusCodeInput) {
+   HttpResponseStatusCodeInput input;
+   Network::ConnectionInfoSetterImpl connection_info_provider(
+       std::make_shared<Network::Address::Ipv4Instance>(80),
+       std::make_shared<Network::Address::Ipv4Instance>(80));
+-  HttpMatchingDataImpl data(connection_info_provider);
++  HttpMatchingDataImpl data(createStreamInfo());
+ 
+   {
+     auto result = input.get(data);
+@@ -47,7 +62,7 @@ TEST(MatchingData, HttpResponseStatusCodeClassInput) {
+   Network::ConnectionInfoSetterImpl connection_info_provider(
+       std::make_shared<Network::Address::Ipv4Instance>(80),
+       std::make_shared<Network::Address::Ipv4Instance>(80));
+-  HttpMatchingDataImpl data(connection_info_provider);
++  HttpMatchingDataImpl data(createStreamInfo());
+   {
+     auto result = input.get(data);
+     EXPECT_EQ(result.data_availability_,
+diff --git a/test/common/network/matching/inputs_test.cc b/test/common/network/matching/inputs_test.cc
+index c673a6220f..cf412193ab 100644
+--- test/common/network/matching/inputs_test.cc
++++ test/common/network/matching/inputs_test.cc
+@@ -36,14 +36,16 @@ TEST(MatchingData, DestinationIPInput) {
+ }
+ 
+ TEST(MatchingData, HttpDestinationIPInput) {
+-  ConnectionInfoSetterImpl connection_info_provider(
++  auto connection_info_provider = std::make_shared<Network::ConnectionInfoSetterImpl>(
+       std::make_shared<Address::Ipv4Instance>("127.0.0.1", 8080),
+       std::make_shared<Address::Ipv4Instance>("10.0.0.1", 9090));
+-  connection_info_provider.setDirectRemoteAddressForTest(
++  connection_info_provider->setDirectRemoteAddressForTest(
+       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.2", 8081));
+   auto host = "example.com";
+-  connection_info_provider.setRequestedServerName(host);
+-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
++  connection_info_provider->setRequestedServerName(host);
++  StreamInfo::StreamInfoImpl stream_info(
++      Http::Protocol::Http2, Event::GlobalTimeSystem().timeSystem(), connection_info_provider);
++  Http::Matching::HttpMatchingDataImpl data(stream_info);
+   {
+     DestinationIPInput<Http::HttpMatchingData> input;
+     const auto result = input.get(data);
+@@ -87,7 +89,7 @@ TEST(MatchingData, HttpDestinationIPInput) {
+     EXPECT_EQ(result.data_, host);
+   }
+ 
+-  connection_info_provider.setRemoteAddress(
++  connection_info_provider->setRemoteAddress(
+       std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 8081));
+   {
+     SourceTypeInput<Http::HttpMatchingData> input;
+diff --git a/test/common/ssl/matching/BUILD b/test/common/ssl/matching/BUILD
+index a0800713b7..da634091d2 100644
+--- test/common/ssl/matching/BUILD
++++ test/common/ssl/matching/BUILD
+@@ -17,6 +17,7 @@ envoy_cc_test(
+         "//source/common/network:socket_lib",
+         "//source/common/ssl/matching:inputs_lib",
+         "//test/mocks/ssl:ssl_mocks",
++        "//test/mocks/stream_info:stream_info_mocks",
+     ],
+ )
+ 
+@@ -30,5 +31,6 @@ envoy_cc_test(
+         "//test/common/matcher:test_utility_lib",
+         "//test/mocks/matcher:matcher_mocks",
+         "//test/mocks/server:factory_context_mocks",
++        "//test/test_common:test_time_lib",
+     ],
+ )
+diff --git a/test/common/ssl/matching/inputs_integration_test.cc b/test/common/ssl/matching/inputs_integration_test.cc
+index 99439ca9f8..3d4126ec7b 100644
+--- test/common/ssl/matching/inputs_integration_test.cc
++++ test/common/ssl/matching/inputs_integration_test.cc
+@@ -8,6 +8,7 @@
+ #include "test/mocks/matcher/mocks.h"
+ #include "test/mocks/server/factory_context.h"
+ #include "test/mocks/ssl/mocks.h"
++#include "test/test_common/test_time.h"
+ 
+ #include "gtest/gtest.h"
+ 
+@@ -116,14 +117,12 @@ TEST_F(HttpInputsIntegrationTest, UriSanInput) {
+ 
+   initialize("UriSanInput", host);
+ 
+-  Network::ConnectionInfoSetterImpl connection_info_provider(
+-      std::make_shared<Network::Address::Ipv4Instance>(80),
+-      std::make_shared<Network::Address::Ipv4Instance>(80));
++  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
+-  connection_info_provider.setSslConnection(ssl);
++  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
+   std::vector<std::string> uri_sans{host};
+   EXPECT_CALL(*ssl, uriSanPeerCertificate()).WillOnce(Return(uri_sans));
+-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
++  Http::Matching::HttpMatchingDataImpl data(stream_info);
+ 
+   const auto result = match_tree_()->match(data);
+   EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
+@@ -135,14 +134,12 @@ TEST_F(HttpInputsIntegrationTest, DnsSanInput) {
+ 
+   initialize("DnsSanInput", host);
+ 
+-  Network::ConnectionInfoSetterImpl connection_info_provider(
+-      std::make_shared<Network::Address::Ipv4Instance>(80),
+-      std::make_shared<Network::Address::Ipv4Instance>(80));
++  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
+-  connection_info_provider.setSslConnection(ssl);
++  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
+   std::vector<std::string> dns_sans{host};
+   EXPECT_CALL(*ssl, dnsSansPeerCertificate()).WillOnce(Return(dns_sans));
+-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
++  Http::Matching::HttpMatchingDataImpl data(stream_info);
+ 
+   const auto result = match_tree_()->match(data);
+   EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
+@@ -154,13 +151,11 @@ TEST_F(HttpInputsIntegrationTest, SubjectInput) {
+ 
+   initialize("SubjectInput", host);
+ 
+-  Network::ConnectionInfoSetterImpl connection_info_provider(
+-      std::make_shared<Network::Address::Ipv4Instance>(80),
+-      std::make_shared<Network::Address::Ipv4Instance>(80));
++  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
+-  connection_info_provider.setSslConnection(ssl);
++  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
+   EXPECT_CALL(*ssl, subjectPeerCertificate()).WillOnce(testing::ReturnRef(host));
+-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
++  Http::Matching::HttpMatchingDataImpl data(stream_info);
+ 
+   const auto result = match_tree_()->match(data);
+   EXPECT_EQ(result.match_state_, Matcher::MatchState::MatchComplete);
+diff --git a/test/common/ssl/matching/inputs_test.cc b/test/common/ssl/matching/inputs_test.cc
+index 63bdaee166..56c9510e72 100644
+--- test/common/ssl/matching/inputs_test.cc
++++ test/common/ssl/matching/inputs_test.cc
+@@ -4,6 +4,7 @@
+ #include "source/common/ssl/matching/inputs.h"
+ 
+ #include "test/mocks/ssl/mocks.h"
++#include "test/mocks/stream_info/mocks.h"
+ 
+ namespace Envoy {
+ namespace Ssl {
+@@ -14,10 +15,8 @@ using testing::ReturnRef;
+ 
+ TEST(Authentication, UriSanInput) {
+   UriSanInput<Http::HttpMatchingData> input;
+-  Network::ConnectionInfoSetterImpl connection_info_provider(
+-      std::make_shared<Network::Address::Ipv4Instance>(80),
+-      std::make_shared<Network::Address::Ipv4Instance>(80));
+-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
++  NiceMock<StreamInfo::MockStreamInfo> stream_info;
++  Http::Matching::HttpMatchingDataImpl data(stream_info);
+ 
+   {
+     const auto result = input.get(data);
+@@ -27,7 +26,7 @@ TEST(Authentication, UriSanInput) {
+   }
+ 
+   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
+-  connection_info_provider.setSslConnection(ssl);
++  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
+ 
+   {
+     std::vector<std::string> uri_sans;
+@@ -62,11 +61,8 @@ TEST(Authentication, UriSanInput) {
+ 
+ TEST(Authentication, DnsSanInput) {
+   DnsSanInput<Http::HttpMatchingData> input;
+-  Network::ConnectionInfoSetterImpl connection_info_provider(
+-      std::make_shared<Network::Address::Ipv4Instance>(80),
+-      std::make_shared<Network::Address::Ipv4Instance>(80));
+-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
+-
++  NiceMock<StreamInfo::MockStreamInfo> stream_info;
++  Http::Matching::HttpMatchingDataImpl data(stream_info);
+   {
+     const auto result = input.get(data);
+     EXPECT_EQ(result.data_availability_,
+@@ -75,8 +71,7 @@ TEST(Authentication, DnsSanInput) {
+   }
+ 
+   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
+-  connection_info_provider.setSslConnection(ssl);
+-
++  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
+   {
+     std::vector<std::string> dns_sans;
+     EXPECT_CALL(*ssl, dnsSansPeerCertificate()).WillRepeatedly(Return(dns_sans));
+@@ -110,10 +105,9 @@ TEST(Authentication, DnsSanInput) {
+ 
+ TEST(Authentication, SubjectInput) {
+   SubjectInput<Http::HttpMatchingData> input;
+-  Network::ConnectionInfoSetterImpl connection_info_provider(
+-      std::make_shared<Network::Address::Ipv4Instance>(80),
+-      std::make_shared<Network::Address::Ipv4Instance>(80));
+-  Http::Matching::HttpMatchingDataImpl data(connection_info_provider);
++
++  NiceMock<StreamInfo::MockStreamInfo> stream_info;
++  Http::Matching::HttpMatchingDataImpl data(stream_info);
+ 
+   {
+     const auto result = input.get(data);
+@@ -123,7 +117,8 @@ TEST(Authentication, SubjectInput) {
+   }
+ 
+   std::shared_ptr<Ssl::MockConnectionInfo> ssl = std::make_shared<Ssl::MockConnectionInfo>();
+-  connection_info_provider.setSslConnection(ssl);
++  stream_info.downstream_connection_info_provider_->setSslConnection(ssl);
++  // connection_info_provider->setSslConnection(ssl);
+   std::string subject;
+   EXPECT_CALL(*ssl, subjectPeerCertificate()).WillRepeatedly(ReturnRef(subject));
+ 
+diff --git a/test/extensions/common/matcher/trie_matcher_test.cc b/test/extensions/common/matcher/trie_matcher_test.cc
+index 1d1e9dc92f..f9bf6299e9 100644
+--- test/extensions/common/matcher/trie_matcher_test.cc
++++ test/extensions/common/matcher/trie_matcher_test.cc
+@@ -621,10 +621,13 @@ matcher_tree:
+       context, factory_context, validation_visitor);
+   auto match_tree = matcher_factory.create(matcher);
+ 
++  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+   const Network::Address::InstanceConstSharedPtr address =
+       std::make_shared<Network::Address::Ipv4Instance>("192.168.0.1", 8080);
+-  Network::ConnectionInfoSetterImpl connection_info(address, address);
+-  Http::Matching::HttpMatchingDataImpl data(connection_info);
++  stream_info.downstream_connection_info_provider_->setLocalAddress(address);
++  stream_info.downstream_connection_info_provider_->setRemoteAddress(address);
++
++  Http::Matching::HttpMatchingDataImpl data(stream_info);
+ 
+   const auto result = match_tree()->match(data);
+   EXPECT_EQ(result.match_state_, MatchState::MatchComplete);
+diff --git a/test/extensions/filters/common/rbac/engine_impl_test.cc b/test/extensions/filters/common/rbac/engine_impl_test.cc
+index 8b2c6d975a..872336d674 100644
+--- test/extensions/filters/common/rbac/engine_impl_test.cc
++++ test/extensions/filters/common/rbac/engine_impl_test.cc
+@@ -18,6 +18,7 @@
+ #include "gtest/gtest.h"
+ 
+ using testing::Const;
++using testing::ReturnPointee;
+ using testing::ReturnRef;
+ 
+ namespace Envoy {
+@@ -66,7 +67,6 @@ void checkMatcherEngine(
+     StreamInfo::StreamInfo& info,
+     const Envoy::Network::Connection& connection = Envoy::Network::MockConnection(),
+     const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::TestRequestHeaderMapImpl()) {
+-
+   bool engineRes = engine.handleAction(connection, headers, info, nullptr);
+   EXPECT_EQ(expected, engineRes);
+ 
+@@ -88,7 +88,6 @@ void checkMatcherEngine(
+     RBAC::RoleBasedAccessControlMatcherEngineImpl& engine, bool expected, LogResult expected_log,
+     const Envoy::Network::Connection& connection,
+     const Envoy::Http::RequestHeaderMap& headers = Envoy::Http::TestRequestHeaderMapImpl()) {
+-
+   NiceMock<StreamInfo::MockStreamInfo> empty_info;
+   checkMatcherEngine(engine, expected, expected_log, empty_info, connection, headers);
+ }
+@@ -473,11 +472,7 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, Disabled) {
+   RBAC::RoleBasedAccessControlMatcherEngineImpl engine(matcher, factory_context,
+                                                        validation_visitor);
+ 
+-  Envoy::Network::MockConnection conn;
+-  Network::ConnectionInfoSetterImpl provider(std::make_shared<Network::Address::Ipv4Instance>(80),
+-                                             std::make_shared<Network::Address::Ipv4Instance>(80));
+-  EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
+-
++  NiceMock<Envoy::Network::MockConnection> conn;
+   checkMatcherEngine(engine, false, LogResult::Undecided, conn);
+ }
+ 
+@@ -510,20 +505,24 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, AllowedAllowlist) {
+   RBAC::RoleBasedAccessControlMatcherEngineImpl engine(matcher, factory_context,
+                                                        validation_visitor);
+ 
+-  Envoy::Network::MockConnection conn;
++  NiceMock<Envoy::Network::MockConnection> conn;
+   Envoy::Http::TestRequestHeaderMapImpl headers;
+-  NiceMock<StreamInfo::MockStreamInfo> info;
+-  Network::ConnectionInfoSetterImpl provider(std::make_shared<Network::Address::Ipv4Instance>(80),
+-                                             std::make_shared<Network::Address::Ipv4Instance>(80));
+-  EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
++  NiceMock<StreamInfo::MockStreamInfo> stream_info;
++
++  EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(stream_info));
++
+   Envoy::Network::Address::InstanceConstSharedPtr addr =
+       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+-  provider.setLocalAddress(addr);
+-  checkMatcherEngine(engine, true, LogResult::Undecided, info, conn, headers);
++  stream_info.downstream_connection_info_provider_->setLocalAddress(addr);
++
++  EXPECT_CALL(stream_info, downstreamAddressProvider())
++      .WillRepeatedly(ReturnRef(stream_info.downstreamAddressProvider()));
++
++  checkMatcherEngine(engine, true, LogResult::Undecided, stream_info, conn, headers);
+ 
+   addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+-  provider.setLocalAddress(addr);
+-  checkMatcherEngine(engine, false, LogResult::Undecided, info, conn, headers);
++  stream_info.downstream_connection_info_provider_->setLocalAddress(addr);
++  checkMatcherEngine(engine, false, LogResult::Undecided, stream_info, conn, headers);
+ }
+ 
+ TEST(RoleBasedAccessControlMatcherEngineImpl, DeniedDenylist) {
+@@ -555,19 +554,19 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, DeniedDenylist) {
+   RBAC::RoleBasedAccessControlMatcherEngineImpl engine(matcher, factory_context,
+                                                        validation_visitor);
+ 
+-  Envoy::Network::MockConnection conn;
++  NiceMock<Envoy::Network::MockConnection> conn;
+   Envoy::Http::TestRequestHeaderMapImpl headers;
+   NiceMock<StreamInfo::MockStreamInfo> info;
+-  Network::ConnectionInfoSetterImpl provider(std::make_shared<Network::Address::Ipv4Instance>(80),
+-                                             std::make_shared<Network::Address::Ipv4Instance>(80));
+-  EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
++
+   Envoy::Network::Address::InstanceConstSharedPtr addr =
+       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+-  provider.setLocalAddress(addr);
++  info.downstream_connection_info_provider_->setLocalAddress(addr);
++  EXPECT_CALL(info, downstreamAddressProvider())
++      .WillRepeatedly(ReturnPointee(info.downstream_connection_info_provider_));
+   checkMatcherEngine(engine, false, LogResult::Undecided, info, conn, headers);
+ 
+   addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+-  provider.setLocalAddress(addr);
++  info.downstream_connection_info_provider_->setLocalAddress(addr);
+   checkMatcherEngine(engine, true, LogResult::Undecided, info, conn, headers);
+ }
+ 
+@@ -638,21 +637,21 @@ TEST(RoleBasedAccessControlMatcherEngineImpl, LogIfMatched) {
+   RBAC::RoleBasedAccessControlMatcherEngineImpl engine(matcher, factory_context,
+                                                        validation_visitor);
+ 
+-  Envoy::Network::MockConnection conn;
++  NiceMock<Envoy::Network::MockConnection> conn;
+   Envoy::Http::TestRequestHeaderMapImpl headers;
+   NiceMock<StreamInfo::MockStreamInfo> info;
+-  Network::ConnectionInfoSetterImpl provider(std::make_shared<Network::Address::Ipv4Instance>(80),
+-                                             std::make_shared<Network::Address::Ipv4Instance>(80));
+-  EXPECT_CALL(conn, connectionInfoProvider()).WillRepeatedly(ReturnRef(provider));
+   onMetadata(info);
+ 
+   Envoy::Network::Address::InstanceConstSharedPtr addr =
+       Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 123, false);
+-  provider.setLocalAddress(addr);
++  info.downstream_connection_info_provider_->setLocalAddress(addr);
++  EXPECT_CALL(info, downstreamAddressProvider())
++      .WillRepeatedly(ReturnPointee(info.downstream_connection_info_provider_));
++  EXPECT_CALL(conn, streamInfo()).WillRepeatedly(ReturnRef(info));
+   checkMatcherEngine(engine, true, RBAC::LogResult::Yes, info, conn, headers);
+ 
+   addr = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", 456, false);
+-  provider.setLocalAddress(addr);
++  info.downstream_connection_info_provider_->setLocalAddress(addr);
+   checkMatcherEngine(engine, true, RBAC::LogResult::No, info, conn, headers);
+ }
+ 
+diff --git a/test/extensions/filters/http/rbac/rbac_filter_test.cc b/test/extensions/filters/http/rbac/rbac_filter_test.cc
+index 659fc0ab4e..f15390c379 100644
+--- test/extensions/filters/http/rbac/rbac_filter_test.cc
++++ test/extensions/filters/http/rbac/rbac_filter_test.cc
+@@ -22,6 +22,7 @@
+ using testing::_;
+ using testing::NiceMock;
+ using testing::Return;
++using testing::ReturnPointee;
+ using testing::ReturnRef;
+ 
+ namespace Envoy {
+@@ -172,24 +173,23 @@ on_no_match:
+     filter_->setDecoderFilterCallbacks(callbacks_);
+   }
+ 
+-  RoleBasedAccessControlFilterTest()
+-      : provider_(std::make_shared<Network::Address::Ipv4Instance>(80),
+-                  std::make_shared<Network::Address::Ipv4Instance>(80)){};
++  RoleBasedAccessControlFilterTest() = default;
+ 
+   void setDestinationPort(uint16_t port) {
+     address_ = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", port, false);
+     req_info_.downstream_connection_info_provider_->setLocalAddress(address_);
+ 
+-    provider_.setLocalAddress(address_);
+-    ON_CALL(connection_, connectionInfoProvider()).WillByDefault(ReturnRef(provider_));
++    ON_CALL(connection_.stream_info_, downstreamAddressProvider())
++        .WillByDefault(ReturnPointee(req_info_.downstream_connection_info_provider_));
+   }
+ 
+   void setRequestedServerName(std::string server_name) {
+     requested_server_name_ = server_name;
+     ON_CALL(connection_, requestedServerName()).WillByDefault(Return(requested_server_name_));
+ 
+-    provider_.setRequestedServerName(server_name);
+-    ON_CALL(connection_, connectionInfoProvider()).WillByDefault(ReturnRef(provider_));
++    req_info_.downstream_connection_info_provider_->setRequestedServerName(server_name);
++    ON_CALL(connection_.stream_info_, downstreamAddressProvider())
++        .WillByDefault(ReturnPointee(req_info_.downstream_connection_info_provider_));
+   }
+ 
+   void checkAccessLogMetadata(LogResult expected) {
+@@ -233,7 +233,6 @@ on_no_match:
+   std::unique_ptr<RoleBasedAccessControlFilter> filter_;
+ 
+   Network::Address::InstanceConstSharedPtr address_;
+-  Network::ConnectionInfoSetterImpl provider_;
+   std::string requested_server_name_;
+   Http::TestRequestHeaderMapImpl headers_;
+   Http::TestRequestTrailerMapImpl trailers_;
+diff --git a/test/extensions/filters/network/rbac/filter_test.cc b/test/extensions/filters/network/rbac/filter_test.cc
+index 48b330552e..cffdf4c03e 100644
+--- test/extensions/filters/network/rbac/filter_test.cc
++++ test/extensions/filters/network/rbac/filter_test.cc
+@@ -17,6 +17,7 @@
+ 
+ using testing::NiceMock;
+ using testing::Return;
++using testing::ReturnPointee;
+ using testing::ReturnRef;
+ 
+ namespace Envoy {
+@@ -167,9 +168,7 @@ on_no_match:
+     filter_->initializeReadFilterCallbacks(callbacks_);
+   }
+ 
+-  RoleBasedAccessControlNetworkFilterTest()
+-      : provider_(std::make_shared<Network::Address::Ipv4Instance>(80),
+-                  std::make_shared<Network::Address::Ipv4Instance>(80)) {
++  RoleBasedAccessControlNetworkFilterTest() {
+     EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
+     EXPECT_CALL(callbacks_.connection_, streamInfo()).WillRepeatedly(ReturnRef(stream_info_));
+ 
+@@ -179,10 +178,10 @@ on_no_match:
+ 
+   void setDestinationPort(uint16_t port) {
+     address_ = Envoy::Network::Utility::parseInternetAddress("1.2.3.4", port, false);
+-    stream_info_.downstream_connection_info_provider_->setLocalAddress(address_);
+ 
+-    provider_.setLocalAddress(address_);
+-    ON_CALL(callbacks_.connection_, connectionInfoProvider()).WillByDefault(ReturnRef(provider_));
++    stream_info_.downstream_connection_info_provider_->setLocalAddress(address_);
++    ON_CALL(callbacks_.connection_.stream_info_, downstreamAddressProvider())
++        .WillByDefault(ReturnPointee(stream_info_.downstream_connection_info_provider_));
+   }
+ 
+   void setRequestedServerName(std::string server_name) {
+@@ -190,8 +189,10 @@ on_no_match:
+     ON_CALL(callbacks_.connection_, requestedServerName())
+         .WillByDefault(Return(requested_server_name_));
+ 
+-    provider_.setRequestedServerName(requested_server_name_);
+-    ON_CALL(callbacks_.connection_, connectionInfoProvider()).WillByDefault(ReturnRef(provider_));
++    stream_info_.downstream_connection_info_provider_->setRequestedServerName(
++        requested_server_name_);
++    ON_CALL(callbacks_.connection_.stream_info_, downstreamAddressProvider())
++        .WillByDefault(ReturnPointee(stream_info_.downstream_connection_info_provider_));
+   }
+ 
+   void checkAccessLogMetadata(bool expected) {
+@@ -230,7 +231,6 @@ on_no_match:
+ 
+   std::unique_ptr<RoleBasedAccessControlFilter> filter_;
+   Network::Address::InstanceConstSharedPtr address_;
+-  Network::ConnectionInfoSetterImpl provider_;
+   std::string requested_server_name_;
+ };
+ 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -73,6 +73,7 @@ def envoy_gloo_dependencies():
     _repository_impl("envoy", patches = [
             "@envoy_gloo//bazel/foreign_cc:filter-state-matching-input-25.patch", # https://github.com/envoyproxy/envoy/pull/25856
             "@envoy_gloo//bazel/foreign_cc:dynamic-metadata-matchingdata-25.patch", # https://github.com/envoyproxy/envoy/pull/26311
+            "@envoy_gloo//bazel/foreign_cc:matcher-updates-25.patch",
         ])
     _repository_impl("json", build_file = "@envoy_gloo//bazel/external:json.BUILD")
     _repository_impl("inja", build_file = "@envoy_gloo//bazel/external:inja.BUILD")

--- a/changelog/v1.25.10-patch2/transformation-matcher.yaml
+++ b/changelog/v1.25.10-patch2/transformation-matcher.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/12181
+  resolvesIssue: false
+  description: >-
+    Support using unified matcher API for transformation filter.

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/filters/http/aws_lambda/config.h"
 
 #include "source/extensions/filters/http/transformation/transformation_filter_config.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
 
 #include "envoy/thread_local/thread_local.h"
 

--- a/source/extensions/filters/http/transformation/BUILD
+++ b/source/extensions/filters/http/transformation/BUILD
@@ -30,15 +30,54 @@ envoy_cc_library(
     ],
     repository = "@envoy",
     deps = [
+        ":filter_config_lib",
+        ":transformation_logger_lib",
+        ":transformation_factory_lib",
+        ":matcher_lib",
+        "//source/extensions/filters/http:solo_well_known_names",
+        "//api/envoy/config/filter/http/transformation/v2:pkg_cc_proto",
+        "@envoy//envoy/router:router_interface",
+        "@envoy//envoy/config:typed_config_interface",
+        "@envoy//source/common/protobuf:message_validator_lib",
+    ],
+)
+envoy_cc_library(
+    name = "transformation_factory_lib",
+    srcs = [
+        "transformation_factory.cc",
+    ],
+    hdrs = [
+        "transformation_factory.h",
+    ],
+    repository = "@envoy",
+    deps = [
         ":body_header_transformer_lib",
         ":inja_transformer_lib",
-        ":transformer_lib",
         ":transformation_logger_lib",
         "//source/extensions/filters/http:solo_well_known_names",
         "//api/envoy/config/filter/http/transformation/v2:pkg_cc_proto",
         "@envoy//envoy/router:router_interface",
         "@envoy//envoy/config:typed_config_interface",
         "@envoy//source/common/protobuf:message_validator_lib",
+        "@envoy//source/common/config:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "matcher_lib",
+    srcs = [
+        "matcher.cc",
+    ],
+    hdrs = [
+        "matcher.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":transformer_lib",
+        ":transformation_factory_lib",
+        "//api/envoy/config/filter/http/transformation/v2:pkg_cc_proto",
+        "@envoy//source/common/http/matching:data_impl_lib",
+        "@envoy//source/common/matcher:matcher_lib",
     ],
 )
 
@@ -113,11 +152,29 @@ envoy_cc_library(
     hdrs = [
         "transformer.h",
     ],
+    repository = "@envoy",
+    deps = [
+        "@envoy//envoy/buffer:buffer_interface",
+        "@envoy//envoy/http:header_map_interface",
+        "@envoy//envoy/http:filter_interface",
+        "@envoy//envoy/router:router_interface",
+        "@envoy//source/common/http:header_utility_lib",
+        "@envoy//source/extensions/filters/http/common:factory_base_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_config_lib",
+    hdrs = [
+        "filter_config.h",
+    ],
     srcs = [
-        "transformer.cc",
+        "filter_config.cc",
     ],
     repository = "@envoy",
     deps = [
+        ":transformer_lib",
+        ":matcher_lib",
         "//source/common/matcher:matchers_lib",
         "@envoy//envoy/buffer:buffer_interface",
         "@envoy//envoy/http:header_map_interface",

--- a/source/extensions/filters/http/transformation/body_header_transformer.h
+++ b/source/extensions/filters/http/transformation/body_header_transformer.h
@@ -3,6 +3,7 @@
 #include <map>
 
 #include "source/extensions/filters/http/transformation/transformer.h"
+#include "source/common/http/header_utility.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/source/extensions/filters/http/transformation/filter_config.cc
+++ b/source/extensions/filters/http/transformation/filter_config.cc
@@ -1,4 +1,5 @@
-#include "source/extensions/filters/http/transformation/transformer.h"
+#include "source/extensions/filters/http/transformation/filter_config.h"
+#include "source/extensions/filters/http/transformation/matcher.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -9,17 +10,14 @@ namespace {
 constexpr uint64_t MAX_STAGE_NUMBER = 10UL;
 }
 
-TransformerPair::TransformerPair(TransformerConstSharedPtr request_transformer,
-                                 TransformerConstSharedPtr response_transformer,
-                                 TransformerConstSharedPtr on_stream_completion_transformer,
-                                 bool should_clear_cache)
-    : clear_route_cache_(should_clear_cache),
-      request_transformation_(request_transformer),
-      response_transformation_(response_transformer),
-      on_stream_completion_transformation_(on_stream_completion_transformer) {}
-
 TransformerPairConstSharedPtr
-FilterConfig::findTransformers(const Http::RequestHeaderMap &headers) const {
+FilterConfig::findTransformers(const Http::RequestHeaderMap &headers, StreamInfo::StreamInfo& si) const {
+  auto match = matcher();
+  if (match) {
+      Http::Matching::HttpMatchingDataImpl data(si);
+      data.onRequestHeaders(headers);
+      return matchTransform(std::move(data), match); 
+  }
   for (const auto &pair : transformerPairs()) {
     if (pair.matcher()->matches(headers)) {
       return pair.transformer_pair();

--- a/source/extensions/filters/http/transformation/filter_config.h
+++ b/source/extensions/filters/http/transformation/filter_config.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/http/filter.h"
+#include "envoy/http/header_map.h"
+#include "envoy/router/router.h"
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats_macros.h"
+
+#include "source/common/http/header_utility.h"
+#include "source/common/matcher/solo_matcher.h"
+#include "source/common/protobuf/protobuf.h"
+
+#include "source/extensions/filters/http/transformation/transformer.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+/**
+ * All stats for the transformation filter. @see stats_macros.h
+ */
+#define ALL_TRANSFORMATION_FILTER_STATS(COUNTER)                               \
+  COUNTER(request_body_transformations)                                        \
+  COUNTER(request_header_transformations)                                      \
+  COUNTER(response_header_transformations)                                     \
+  COUNTER(response_body_transformations)                                       \
+  COUNTER(request_error)                                                       \
+  COUNTER(response_error)                                                      \
+  COUNTER(on_stream_complete_error)
+
+/**
+ * Wrapper struct for transformation @see stats_macros.h
+ */
+struct TransformationFilterStats {
+  ALL_TRANSFORMATION_FILTER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+class TransformConfig {
+public:
+  virtual ~TransformConfig() {}
+  virtual TransformerPairConstSharedPtr
+  findTransformers(const Http::RequestHeaderMap &headers, StreamInfo::StreamInfo& info) const PURE;
+  virtual TransformerConstSharedPtr
+  findResponseTransform(const Http::ResponseHeaderMap &headers,
+                        StreamInfo::StreamInfo &) const PURE;
+};
+
+class StagedTransformConfig {
+public:
+  virtual ~StagedTransformConfig() {}
+  virtual const TransformConfig *
+  transformConfigForStage(uint32_t stage) const PURE;
+};
+
+class MatcherTransformerPair {
+public:
+  MatcherTransformerPair(Matcher::MatcherConstPtr matcher,
+                         TransformerPairConstSharedPtr transformer_pair)
+      : matcher_(matcher), transformer_pair_(transformer_pair) {}
+
+  TransformerPairConstSharedPtr transformer_pair() const {
+    return transformer_pair_;
+  }
+
+  Matcher::MatcherConstPtr matcher() const { return matcher_; }
+
+private:
+  Matcher::MatcherConstPtr matcher_;
+  TransformerPairConstSharedPtr transformer_pair_;
+};
+
+class FilterConfig : public TransformConfig {
+public:
+  FilterConfig(const std::string &prefix, Stats::Scope &scope, uint32_t stage, bool log_request_response_info)
+      : stats_(generateStats(prefix, scope)), stage_(stage), log_request_response_info_(log_request_response_info) {}
+
+  static TransformationFilterStats generateStats(const std::string &prefix,
+                                                 Stats::Scope &scope);
+
+
+  // Finds the matcher that matched the header
+  TransformerPairConstSharedPtr
+  findTransformers(const Http::RequestHeaderMap &headers, StreamInfo::StreamInfo& info) const override;
+
+  TransformerConstSharedPtr
+  findResponseTransform(const Http::ResponseHeaderMap &,
+                        StreamInfo::StreamInfo &) const override {
+    return nullptr;
+  }
+
+  TransformationFilterStats &stats() { return stats_; }
+
+  virtual std::string name() const PURE;
+
+  uint32_t stage() const { return stage_; }
+
+  bool logRequestResponseInfo() const { return log_request_response_info_; }
+protected:
+
+  virtual const std::vector<MatcherTransformerPair> &
+    transformerPairs() const PURE;
+
+  virtual Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher() const {return nullptr;};
+
+private:
+  TransformationFilterStats stats_;
+  uint32_t stage_{};
+  bool log_request_response_info_{};
+};
+
+class RouteFilterConfig : public Router::RouteSpecificFilterConfig,
+                          public StagedTransformConfig {
+public:
+  RouteFilterConfig();
+
+  const TransformConfig *transformConfigForStage(uint32_t stage) const override;
+
+protected:
+  std::vector<std::unique_ptr<const TransformConfig>> stages_;
+};
+
+typedef std::shared_ptr<const RouteFilterConfig>
+    RouteFilterConfigConstSharedPtr;
+typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
+
+} // namespace Transformation
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -8,6 +8,8 @@
 
 #include "source/common/common/base64.h"
 
+#include "envoy/thread_local/thread_local_object.h"
+#include "envoy/thread_local/thread_local.h"
 #include "source/extensions/filters/http/transformation/transformer.h"
 
 // clang-format off

--- a/source/extensions/filters/http/transformation/matcher.cc
+++ b/source/extensions/filters/http/transformation/matcher.cc
@@ -1,0 +1,97 @@
+#include "api/envoy/config/filter/http/transformation/v2/transformation_filter.pb.validate.h"
+#include "source/extensions/filters/http/transformation/matcher.h"
+#include "source/common/matcher/matcher.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+class TransformationAction : public Envoy::Matcher::ActionBase<envoy::api::v2::filter::http::TransformationRule_Transformations> {
+public:
+  TransformationAction(TransformerPairConstSharedPtr transformations)
+      : transformations_(std::move(transformations)) {}
+
+  TransformerPairConstSharedPtr transformations() const { return transformations_; }
+
+private:
+  const std::string name_;
+  TransformerPairConstSharedPtr transformations_;
+};
+
+TransformerPairConstSharedPtr matchTransform(Http::Matching::HttpMatchingDataImpl&& data, const Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData>& matcher) {
+    auto match = Matcher::evaluateMatch<Http::HttpMatchingData>(*matcher, data);
+    if (match.result_) {
+      auto action = match.result_();
+
+      // The only possible action that can be used within the route matching context
+      // is the TransformationAction, so this must be true.
+      ASSERT(action->typeUrl() == TransformationAction::staticTypeUrl());
+      ASSERT(dynamic_cast<TransformationAction*>(action.get()));
+      const TransformationAction& transformation_action = static_cast<const TransformationAction&>(*action);
+
+      return transformation_action.transformations();
+    }
+    return nullptr;
+}
+
+struct TransformationContext {
+  Server::Configuration::ServerFactoryContext &factory_context;
+};
+
+class ActionFactory : public Envoy::Matcher::ActionFactory<TransformationContext> {
+public:
+  Envoy::Matcher::ActionFactoryCb
+  createActionFactoryCb(const Protobuf::Message& config, TransformationContext& context,
+                        ProtobufMessage::ValidationVisitor& validation_visitor) override;
+  std::string name() const override { return "envoy.filters.transformation.action"; }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<envoy::api::v2::filter::http::TransformationRule_Transformations>();
+  }
+};
+
+Envoy::Matcher::ActionFactoryCb
+ActionFactory::createActionFactoryCb(const Protobuf::Message& config, TransformationContext& context,
+                                     ProtobufMessage::ValidationVisitor& validation_visitor) {
+  const auto& action_config =
+      MessageUtil::downcastAndValidate<const envoy::api::v2::filter::http::TransformationRule_Transformations&>(config,
+                                                                               validation_visitor);
+TransformerPairConstSharedPtr transformations = createTransformations(action_config, context.factory_context);
+
+  return [transformations]() { return std::make_unique<TransformationAction>(transformations); };
+}
+
+REGISTER_FACTORY(ActionFactory, Envoy::Matcher::ActionFactory<TransformationContext>);
+
+
+class TransformationValidationVisitor
+    : public Matcher::MatchTreeValidationVisitor<Http::HttpMatchingData> {
+public:
+  absl::Status performDataInputValidation(const Matcher::DataInputFactory<Http::HttpMatchingData>&,
+                                          absl::string_view) override {
+    return absl::OkStatus();
+  }
+};
+
+Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> createTransformationMatcher(
+    const xds::type::matcher::v3::Matcher &matcher_config,
+    Server::Configuration::ServerFactoryContext &factory_context) {
+
+  TransformationContext context{factory_context};
+  TransformationValidationVisitor validation_visitor;
+  Envoy::Matcher::MatchTreeFactory<Http::HttpMatchingData, TransformationContext> factory(
+      context, factory_context, validation_visitor);
+  auto matcher = factory.create(matcher_config)();
+
+  if (!validation_visitor.errors().empty()) {
+    throw EnvoyException(fmt::format("error creating transformation: {}",
+                                     validation_visitor.errors()[0]));
+  }
+  return matcher;
+}
+
+}  // namespace Transformation
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/source/extensions/filters/http/transformation/matcher.h
+++ b/source/extensions/filters/http/transformation/matcher.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+#include "source/common/http/matching/data_impl.h"
+#include "envoy/matcher/matcher.h"
+#include "source/extensions/filters/http/transformation/transformer.h"
+#include "envoy/server/factory_context.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+TransformerPairConstSharedPtr matchTransform(Http::Matching::HttpMatchingDataImpl&& data, const Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData>& matcher);
+
+Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> createTransformationMatcher(
+    const xds::type::matcher::v3::Matcher &matcher,
+    Server::Configuration::ServerFactoryContext &factory_context);
+
+} // namespace Transformation
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/transformation/transformation_factory.cc
+++ b/source/extensions/filters/http/transformation/transformation_factory.cc
@@ -1,0 +1,81 @@
+#include "api/envoy/config/filter/http/transformation/v2/transformation_filter.pb.validate.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
+#include "source/extensions/filters/http/transformation/body_header_transformer.h"
+#include "source/extensions/filters/http/transformation/inja_transformer.h"
+#include "source/common/config/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+TransformerConstSharedPtr Transformation::getTransformer(
+    const envoy::api::v2::filter::http::Transformation &transformation,
+    Server::Configuration::CommonFactoryContext &context) {
+  switch (transformation.transformation_type_case()) {
+  case envoy::api::v2::filter::http::Transformation::kTransformationTemplate:
+    return std::make_unique<InjaTransformer>(
+        transformation.transformation_template(), context.api().randomGenerator(), transformation.log_request_response_info(), context.threadLocal());
+  case envoy::api::v2::filter::http::Transformation::kHeaderBodyTransform: {
+    const auto& header_body_transform = transformation.header_body_transform();
+    return std::make_unique<BodyHeaderTransformer>(header_body_transform.add_request_metadata(), transformation.log_request_response_info());
+  }
+  case envoy::api::v2::filter::http::Transformation::kTransformerConfig: {
+    auto &factory = Config::Utility::getAndCheckFactory<TransformerExtensionFactory>(transformation.transformer_config());
+    auto config = Config::Utility::translateAnyToFactoryConfig(transformation.transformer_config().typed_config(), context.messageValidationContext().staticValidationVisitor(), factory);
+    return factory.createTransformer(*config, transformation.log_request_response_info(), context);
+  }
+  case envoy::api::v2::filter::http::Transformation::
+      TRANSFORMATION_TYPE_NOT_SET:
+    ENVOY_LOG(trace, "Request transformation type not set");
+    FALLTHRU;
+  default:
+    throw EnvoyException("non existent transformation");
+  }
+}
+
+std::unique_ptr<const TransformerPair> createTransformations(const envoy::api::v2::filter::http::TransformationRule_Transformations& route_transformation,
+    Server::Configuration::CommonFactoryContext &context) {
+    bool clear_route_cache = route_transformation.clear_route_cache();
+    TransformerConstSharedPtr request_transformation;
+    TransformerConstSharedPtr response_transformation;
+    TransformerConstSharedPtr on_stream_completion_transformation;
+    if (route_transformation.has_request_transformation()) {
+      try {
+        request_transformation = Transformation::getTransformer(
+            route_transformation.request_transformation(), context);
+      } catch (const std::exception &e) {
+        throw EnvoyException(
+            fmt::format("Failed to parse request template: {}", e.what()));
+      }
+    }
+    if (route_transformation.has_response_transformation()) {
+      try {
+        response_transformation = Transformation::getTransformer(
+            route_transformation.response_transformation(), context);
+      } catch (const std::exception &e) {
+        throw EnvoyException(
+            fmt::format("Failed to parse response template: {}", e.what()));
+      }
+    }
+    if (route_transformation.has_on_stream_completion_transformation()) {
+      try {
+        on_stream_completion_transformation = Transformation::getTransformer(
+            route_transformation.on_stream_completion_transformation(),
+            context);
+      } catch (const std::exception &e) {
+        throw EnvoyException(fmt::format(
+            "Failed to get the on stream completion transformation: {}",
+            e.what()));
+      }
+    }
+    return std::make_unique<TransformerPair>(
+          request_transformation, response_transformation,
+          on_stream_completion_transformation, clear_route_cache);
+}
+
+
+}  // namespace Transformation
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/source/extensions/filters/http/transformation/transformation_factory.cc
+++ b/source/extensions/filters/http/transformation/transformation_factory.cc
@@ -15,7 +15,7 @@ TransformerConstSharedPtr Transformation::getTransformer(
   switch (transformation.transformation_type_case()) {
   case envoy::api::v2::filter::http::Transformation::kTransformationTemplate:
     return std::make_unique<InjaTransformer>(
-        transformation.transformation_template(), context.api().randomGenerator(), transformation.log_request_response_info(), context.threadLocal());
+        transformation.transformation_template(), context.api().randomGenerator(), transformation.log_request_response_info());
   case envoy::api::v2::filter::http::Transformation::kHeaderBodyTransform: {
     const auto& header_body_transform = transformation.header_body_transform();
     return std::make_unique<BodyHeaderTransformer>(header_body_transform.add_request_metadata(), transformation.log_request_response_info());

--- a/source/extensions/filters/http/transformation/transformation_factory.h
+++ b/source/extensions/filters/http/transformation/transformation_factory.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/matcher/matcher.h"
+#include "source/extensions/filters/http/transformation/transformer.h"
+#include "envoy/server/factory_context.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+class Transformation : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
+public:
+  static TransformerConstSharedPtr getTransformer(
+      const envoy::api::v2::filter::http::Transformation &transformation,
+      Server::Configuration::CommonFactoryContext &context );
+};
+
+/**
+ * Implemented for transformation extensions and registered via Registry::registerFactory or the
+ * convenience class RegisterFactory.
+ */
+class TransformerExtensionFactory :  public Config::TypedFactory {
+public:
+  ~TransformerExtensionFactory() override = default;
+
+/**
+ * Create a particular transformation extension implementation from a config proto. If the
+ * implementation is unable to produce a factory with the provided parameters, it should throw
+ * EnvoyException. The returned pointer should never be nullptr.
+ * @param config the custom configuration for this transformer extension type.
+ */
+  virtual TransformerConstSharedPtr createTransformer(const Protobuf::Message &config,
+    google::protobuf::BoolValue log_request_response_info,
+    Server::Configuration::CommonFactoryContext &context) PURE;
+
+  virtual std::string name() const override PURE;
+
+  std::string category() const override {return "io.solo.transformer"; }
+};
+
+std::unique_ptr<const TransformerPair> createTransformations(
+    const envoy::api::v2::filter::http::TransformationRule_Transformations& route_transformation,
+    Server::Configuration::CommonFactoryContext &context);
+
+} // namespace Transformation
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/transformation/transformation_filter.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter.cc
@@ -174,7 +174,7 @@ void TransformationFilter::setupTransformationPair() {
       config_to_use = staged_config;
     }
   }
-  active_transformer_pair = config_to_use->findTransformers(*request_headers_);
+  active_transformer_pair = config_to_use->findTransformers(*request_headers_, decoder_callbacks_->streamInfo());
 
   if (active_transformer_pair != nullptr) {
     should_clear_cache_ = active_transformer_pair->shouldClearCache();

--- a/source/extensions/filters/http/transformation/transformation_filter_config.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.cc
@@ -2,13 +2,11 @@
 
 #include "source/common/common/assert.h"
 #include "source/common/common/matchers.h"
-#include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/message_validator_impl.h"
-#include "source/common/config/utility.h"
-
-
-#include "source/extensions/filters/http/transformation/body_header_transformer.h"
-#include "source/extensions/filters/http/transformation/inja_transformer.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/filters/http/transformation/matcher.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
+#include "source/common/matcher/matcher.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -38,59 +36,40 @@ TransformerConstSharedPtr Transformation::getTransformer(
   default:
     throw EnvoyException("non existent transformation");
   }
+  
+void TransformationFilterConfig::addTransformationLegacy(
+    const envoy::api::v2::filter::http::TransformationRule &rule,
+    Server::Configuration::FactoryContext &context) {
+  if (!rule.has_match()) {
+    return;
+  }
+  TransformerConstSharedPtr request_transformation;
+  TransformerConstSharedPtr response_transformation;
+  TransformerConstSharedPtr on_stream_completion_transformation;
+  bool clear_route_cache = false;
+
+  TransformerPairConstSharedPtr transformer_pair = 
+      std::make_unique<TransformerPair>(
+          request_transformation, response_transformation,
+          on_stream_completion_transformation, clear_route_cache);
+  if (rule.has_route_transformations()) {
+    transformer_pair = createTransformations(rule.route_transformations(), context);
+  }
+  transformer_pairs_.emplace_back(Matcher::Matcher::create(rule.match()),
+                                  transformer_pair);
 }
 
 TransformationFilterConfig::TransformationFilterConfig(
     const TransformationConfigProto &proto_config, const std::string &prefix,
     Server::Configuration::FactoryContext &context)
-    : FilterConfig(prefix, context.scope(), proto_config.stage(), proto_config.log_request_response_info()) {
-
+    : FilterConfig(prefix, context.scope(), proto_config.stage(),
+                   proto_config.log_request_response_info()) {
+    if (proto_config.has_matcher()) {
+      matcher_ = createTransformationMatcher(proto_config.matcher(), context.getServerFactoryContext());
+      return;
+    }
   for (const auto &rule : proto_config.transformations()) {
-    if (!rule.has_match()) {
-      continue;
-    }
-    TransformerConstSharedPtr request_transformation;
-    TransformerConstSharedPtr response_transformation;
-    TransformerConstSharedPtr on_stream_completion_transformation;
-    bool clear_route_cache = false;
-    if (rule.has_route_transformations()) {
-      const auto &route_transformation = rule.route_transformations();
-      clear_route_cache = route_transformation.clear_route_cache();
-      if (route_transformation.has_request_transformation()) {
-        try {
-          request_transformation = Transformation::getTransformer(
-              route_transformation.request_transformation(), context);
-        } catch (const std::exception &e) {
-          throw EnvoyException(
-              fmt::format("Failed to parse request template: {}", e.what()));
-        }
-      }
-      if (route_transformation.has_response_transformation()) {
-        try {
-          response_transformation = Transformation::getTransformer(
-              route_transformation.response_transformation(), context);
-        } catch (const std::exception &e) {
-          throw EnvoyException(
-              fmt::format("Failed to parse response template: {}", e.what()));
-        }
-      }
-      if (route_transformation.has_on_stream_completion_transformation()) {
-        try {
-          on_stream_completion_transformation = Transformation::getTransformer(
-              route_transformation.on_stream_completion_transformation(), context);
-        } catch (const std::exception &e) {
-          throw EnvoyException(
-              fmt::format("Failed to get the on stream completion transformation: {}", e.what()));
-        }
-      }
-    }
-    TransformerPairConstSharedPtr transformer_pair =
-        std::make_unique<TransformerPair>(request_transformation,
-                                          response_transformation,
-                                          on_stream_completion_transformation,
-                                          clear_route_cache);
-    transformer_pairs_.emplace_back(Matcher::Matcher::create(rule.match()),
-                                    transformer_pair);
+      addTransformationLegacy(rule, context);
   }
 }
 
@@ -168,11 +147,23 @@ RouteTransformationFilterConfig::RouteTransformationFilterConfig(
       temp_stages[transformation.stage()].reset(
           new PerStageRouteTransformationFilterConfig());
     }
-    temp_stages[transformation.stage()]->addTransformation(transformation, context);
+
+    if (transformation.has_matcher()) {
+      temp_stages[transformation.stage()]->setMatcher(createTransformationMatcher(transformation.matcher(), context));
+    } else {
+      temp_stages[transformation.stage()]->addTransformation(transformation, context);
+    }
   }
   for (uint32_t i = 0; i < stages_.size(); i++) {
     stages_[i] = std::move(temp_stages[i]);
   }
+}
+
+void PerStageRouteTransformationFilterConfig::setMatcher(Envoy::Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher){
+  if (matcher_ != nullptr){
+    throw EnvoyException(fmt::format("Only one matcher is allowed per stage"));
+  }
+  matcher_ = matcher;
 }
 
 void PerStageRouteTransformationFilterConfig::addTransformation(
@@ -213,7 +204,6 @@ void PerStageRouteTransformationFilterConfig::addTransformation(
 
     if (request_transformation != nullptr ||
         response_transformation != nullptr) {
-
       TransformerPairConstSharedPtr transformer_pair =
           std::make_unique<TransformerPair>(request_transformation,
                                             response_transformation,
@@ -250,7 +240,14 @@ void PerStageRouteTransformationFilterConfig::addTransformation(
 
 TransformerPairConstSharedPtr
 PerStageRouteTransformationFilterConfig::findTransformers(
-    const Http::RequestHeaderMap &headers) const {
+    const Http::RequestHeaderMap &headers, StreamInfo::StreamInfo& info) const {
+
+  if (matcher_) {
+      Http::Matching::HttpMatchingDataImpl data(info);
+      data.onRequestHeaders(headers);
+      return matchTransform(std::move(data), matcher_); 
+  }
+
   for (const auto &pair : transformer_pairs_) {
     if (pair.matcher() == nullptr || pair.matcher()->matches(headers)) {
       return pair.transformer_pair();

--- a/source/extensions/filters/http/transformation/transformation_filter_config.cc
+++ b/source/extensions/filters/http/transformation/transformation_filter_config.cc
@@ -12,30 +12,6 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Transformation {
-
-TransformerConstSharedPtr Transformation::getTransformer(
-    const envoy::api::v2::filter::http::Transformation &transformation,
-    Server::Configuration::CommonFactoryContext &context) {
-  switch (transformation.transformation_type_case()) {
-  case envoy::api::v2::filter::http::Transformation::kTransformationTemplate:
-    return std::make_unique<InjaTransformer>(
-        transformation.transformation_template(), context.api().randomGenerator(), transformation.log_request_response_info());
-  case envoy::api::v2::filter::http::Transformation::kHeaderBodyTransform: {
-    const auto& header_body_transform = transformation.header_body_transform();
-    return std::make_unique<BodyHeaderTransformer>(header_body_transform.add_request_metadata(), transformation.log_request_response_info());
-  }
-  case envoy::api::v2::filter::http::Transformation::kTransformerConfig: {
-    auto &factory = Config::Utility::getAndCheckFactory<TransformerExtensionFactory>(transformation.transformer_config());
-    auto config = Config::Utility::translateAnyToFactoryConfig(transformation.transformer_config().typed_config(), context.messageValidationContext().staticValidationVisitor(), factory);
-    return factory.createTransformer(*config, transformation.log_request_response_info(), context);
-  }
-  case envoy::api::v2::filter::http::Transformation::
-      TRANSFORMATION_TYPE_NOT_SET:
-    ENVOY_LOG(trace, "Request transformation type not set");
-    FALLTHRU;
-  default:
-    throw EnvoyException("non existent transformation");
-  }
   
 void TransformationFilterConfig::addTransformationLegacy(
     const envoy::api::v2::filter::http::TransformationRule &rule,

--- a/source/extensions/filters/http/transformation/transformer.h
+++ b/source/extensions/filters/http/transformation/transformer.h
@@ -6,36 +6,13 @@
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 #include "envoy/router/router.h"
-#include "envoy/stats/scope.h"
-#include "envoy/stats/stats_macros.h"
 
-#include "source/common/http/header_utility.h"
-#include "source/common/matcher/solo_matcher.h"
 #include "source/common/protobuf/protobuf.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Transformation {
-
-/**
- * All stats for the transformation filter. @see stats_macros.h
- */
-#define ALL_TRANSFORMATION_FILTER_STATS(COUNTER)                               \
-  COUNTER(request_body_transformations)                                        \
-  COUNTER(request_header_transformations)                                      \
-  COUNTER(response_header_transformations)                                     \
-  COUNTER(response_body_transformations)                                       \
-  COUNTER(request_error)                                                       \
-  COUNTER(response_error)                                                      \
-  COUNTER(on_stream_complete_error)
-
-/**
- * Wrapper struct for transformation @see stats_macros.h
- */
-struct TransformationFilterStats {
-  ALL_TRANSFORMATION_FILTER_STATS(GENERATE_COUNTER_STRUCT)
-};
 
 class Transformer {
 public:
@@ -53,6 +30,7 @@ public:
 
   google::protobuf::BoolValue logRequestResponseInfo() const { return log_request_response_info_; }
 
+private:
   google::protobuf::BoolValue log_request_response_info_{};
 };
 
@@ -63,7 +41,11 @@ public:
   TransformerPair(TransformerConstSharedPtr request_transformer,
                   TransformerConstSharedPtr response_transformer,
                   TransformerConstSharedPtr on_stream_completion_transformer,
-                  bool should_clear_cache);
+                  bool should_clear_cache)
+    : clear_route_cache_(should_clear_cache),
+      request_transformation_(request_transformer),
+      response_transformation_(response_transformer),
+      on_stream_completion_transformation_(on_stream_completion_transformer) {}
 
   TransformerConstSharedPtr getRequestTranformation() const {
     return request_transformation_;
@@ -86,90 +68,6 @@ private:
   TransformerConstSharedPtr on_stream_completion_transformation_;
 };
 typedef std::shared_ptr<const TransformerPair> TransformerPairConstSharedPtr;
-
-class TransformConfig {
-public:
-  virtual ~TransformConfig() {}
-  virtual TransformerPairConstSharedPtr
-  findTransformers(const Http::RequestHeaderMap &headers) const PURE;
-  virtual TransformerConstSharedPtr
-  findResponseTransform(const Http::ResponseHeaderMap &headers,
-                        StreamInfo::StreamInfo &) const PURE;
-};
-
-class StagedTransformConfig {
-public:
-  virtual ~StagedTransformConfig() {}
-  virtual const TransformConfig *
-  transformConfigForStage(uint32_t stage) const PURE;
-};
-
-class MatcherTransformerPair {
-public:
-  MatcherTransformerPair(Matcher::MatcherConstPtr matcher,
-                         TransformerPairConstSharedPtr transformer_pair)
-      : matcher_(matcher), transformer_pair_(transformer_pair) {}
-
-  TransformerPairConstSharedPtr transformer_pair() const {
-    return transformer_pair_;
-  }
-
-  Matcher::MatcherConstPtr matcher() const { return matcher_; }
-
-private:
-  Matcher::MatcherConstPtr matcher_;
-  TransformerPairConstSharedPtr transformer_pair_;
-};
-
-class FilterConfig : public TransformConfig {
-public:
-  FilterConfig(const std::string &prefix, Stats::Scope &scope, uint32_t stage, bool log_request_response_info)
-      : stats_(generateStats(prefix, scope)), stage_(stage), log_request_response_info_(log_request_response_info) {}
-
-  static TransformationFilterStats generateStats(const std::string &prefix,
-                                                 Stats::Scope &scope);
-
-  virtual const std::vector<MatcherTransformerPair> &
-  transformerPairs() const PURE;
-
-  // Finds the matcher that matched the header
-  TransformerPairConstSharedPtr
-  findTransformers(const Http::RequestHeaderMap &headers) const override;
-
-  TransformerConstSharedPtr
-  findResponseTransform(const Http::ResponseHeaderMap &,
-                        StreamInfo::StreamInfo &) const override {
-    return nullptr;
-  }
-
-  TransformationFilterStats &stats() { return stats_; }
-
-  virtual std::string name() const PURE;
-
-  uint32_t stage() const { return stage_; }
-
-  bool logRequestResponseInfo() const { return log_request_response_info_; }
-
-private:
-  TransformationFilterStats stats_;
-  uint32_t stage_{};
-  bool log_request_response_info_{};
-};
-
-class RouteFilterConfig : public Router::RouteSpecificFilterConfig,
-                          public StagedTransformConfig {
-public:
-  RouteFilterConfig();
-
-  const TransformConfig *transformConfigForStage(uint32_t stage) const override;
-
-protected:
-  std::vector<std::unique_ptr<const TransformConfig>> stages_;
-};
-
-typedef std::shared_ptr<const RouteFilterConfig>
-    RouteFilterConfigConstSharedPtr;
-typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
 
 } // namespace Transformation
 } // namespace HttpFilters

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
@@ -6,6 +6,7 @@
 #include "nlohmann/json.hpp"
 
 #include "source/extensions/filters/http/transformation/transformation_filter_config.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
 #include "api/envoy/config/transformer/aws_lambda/v2/api_gateway_transformer.pb.h"
 #include "api/envoy/config/transformer/aws_lambda/v2/api_gateway_transformer.pb.validate.h"
 

--- a/test/extensions/filters/http/aws_lambda/test_transformer.h
+++ b/test/extensions/filters/http/aws_lambda/test_transformer.h
@@ -1,4 +1,5 @@
 #include "source/extensions/filters/http/transformation/transformation_filter_config.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
 #include "test/extensions/filters/http/aws_lambda/api_gateway_test_transformer.pb.h"
 
 namespace Envoy {

--- a/test/extensions/filters/http/transformation/BUILD
+++ b/test/extensions/filters/http/transformation/BUILD
@@ -54,6 +54,19 @@ envoy_gloo_cc_test(
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/mocks/upstream:upstream_mocks",
         "@envoy//test/common/common:logger_test",
+        "@envoy//source/common/http/matching:inputs_lib",
+    ],
+)
+
+envoy_gloo_cc_test(
+    name = "matcher_test",
+    srcs = ["matcher_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//source/extensions/filters/http/transformation:matcher_lib",
+        "@envoy//test/mocks/server:server_mocks",
+        "@envoy//test/mocks/stream_info:stream_info_mocks",
+        "@envoy//source/common/http/matching:inputs_lib",
     ],
 )
 

--- a/test/extensions/filters/http/transformation/fake_transformer.h
+++ b/test/extensions/filters/http/transformation/fake_transformer.h
@@ -1,4 +1,5 @@
 #include "source/extensions/filters/http/transformation/transformation_filter_config.h"
+#include "source/extensions/filters/http/transformation/transformation_factory.h"
 #include "test/extensions/filters/http/transformation/fake_transformer.pb.h"
 
 namespace Envoy {

--- a/test/extensions/filters/http/transformation/matcher_test.cc
+++ b/test/extensions/filters/http/transformation/matcher_test.cc
@@ -1,0 +1,217 @@
+#include "source/extensions/filters/http/transformation/matcher.h"
+
+#include "fmt/format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test/mocks/server/mocks.h"
+#include "test/mocks/stream_info/mocks.h"
+#include "test/test_common/utility.h"
+
+using testing::_;
+using testing::AtLeast;
+using testing::Invoke;
+using testing::Return;
+using testing::ReturnPointee;
+using testing::ReturnRef;
+using testing::SaveArg;
+using testing::Throw;
+using testing::WithArg;
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Transformation {
+
+TransformerPairConstSharedPtr getFromMatcher(std::string s){
+  NiceMock<Server::Configuration::MockServerFactoryContext>
+      server_factory_context;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
+  xds::type::matcher::v3::Matcher matcher;
+  TestUtility::loadFromYaml(s, matcher);
+
+  auto m = createTransformationMatcher(matcher, server_factory_context);
+
+  Http::Matching::HttpMatchingDataImpl data(stream_info);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "GET"}, {":authority", "www.solo.io"}, {":path", "/path"}};
+  data.onRequestHeaders(headers);
+  return matchTransform(std::move(data), m);
+}
+
+TEST(TransformationMatcher, TestGetRequestTransformer) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              request_transformation:
+                transformation_template:
+                  passthrough: {}
+                  headers:
+                    "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_NE(t->getRequestTranformation(), nullptr);
+  EXPECT_EQ(t->getResponseTranformation(), nullptr);
+  EXPECT_EQ(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), false);
+}
+
+TEST(TransformationMatcher, TestGetRequestTransformerClearCache) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              clear_route_cache: true
+              request_transformation:
+                transformation_template:
+                  passthrough: {}
+                  headers:
+                    "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_NE(t->getRequestTranformation(), nullptr);
+  EXPECT_EQ(t->getResponseTranformation(), nullptr);
+  EXPECT_EQ(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), true);
+}
+
+TEST(TransformationMatcher, TestGetResponseTransformer) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              response_transformation:
+                 transformation_template:
+                   passthrough: {}
+                   headers:
+                     "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_EQ(t->getRequestTranformation(), nullptr);
+  EXPECT_NE(t->getResponseTranformation(), nullptr);
+  EXPECT_EQ(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), false);
+}
+
+TEST(TransformationMatcher, TestGetStreamCompleteTransformer) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              on_stream_completion_transformation:
+                 transformation_template:
+                   passthrough: {}
+                   headers:
+                     "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_EQ(t->getRequestTranformation(), nullptr);
+  EXPECT_EQ(t->getResponseTranformation(), nullptr);
+  EXPECT_NE(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), false);
+}
+
+TEST(TransformationMatcher, TestGetTransformOnNonMatch) {
+  auto t = getFromMatcher( R"EOF(
+    matcher_list:
+      matchers:
+      - predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": "type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput"
+                header_name: ":path"
+            value_match:
+              prefix: "/prefix_no_exists"
+        on_match:
+          action:
+            name: action
+            typed_config:
+              "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+              on_stream_completion_transformation:
+                transformation_template:
+                  passthrough: {}
+                  headers:
+                    "x-foo": {text: "matcher"}
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": "type.googleapis.com/envoy.api.v2.filter.http.TransformationRule.Transformations"
+          request_transformation:
+             transformation_template:
+               passthrough: {}
+               headers:
+                 "x-foo": {text: "matcher"}
+  )EOF");
+
+  EXPECT_NE(t, nullptr);
+  EXPECT_NE(t->getRequestTranformation(), nullptr);
+  EXPECT_EQ(t->getResponseTranformation(), nullptr);
+  EXPECT_EQ(t->getOnStreamCompletionTransformation(), nullptr);
+  EXPECT_EQ(t->shouldClearCache(), false);
+}
+
+}  // namespace Transformation
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/test/extensions/filters/http/transformation/transformation_filter_config_test.cc
+++ b/test/extensions/filters/http/transformation/transformation_filter_config_test.cc
@@ -28,7 +28,7 @@ namespace Transformation {
 using FakeTransformerProto = envoy::test::extensions::transformation::FakeTransformer;
 
 
-TEST(TransformerExtensionFactory, TestTransformerExtensionFactoryRegistration){
+TEST(TransformerExtensionFactory, TestTransformerExtensionFactoryRegistration) {
   envoy::api::v2::filter::http::Transformation transformation;
   auto factoryConfig = transformation.mutable_transformer_config();
   factoryConfig->set_name("io.solo.transformer.fake");
@@ -38,7 +38,7 @@ TEST(TransformerExtensionFactory, TestTransformerExtensionFactoryRegistration){
   EXPECT_EQ(factory.name(), "io.solo.transformer.fake");
 }
 
-TEST(Transformation, TestGetTransformer){
+TEST(Transformation, TestGetTransformer) {
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
 
   Transformation t;


### PR DESCRIPTION
# Description
 - Essentially identical to #283, but backport v1.26 matcher functionality using bazel patches, instead of copying the new matcher into a new class in envoy-gloo
 - includes https://github.com/envoyproxy/envoy/pull/25818 as a patch against envoy v1.25
   - This makes streamInfo the input to Http matching data, as opposed to ConnectionInfoProvider
 - Validated in envoy-gloo-ee by https://github.com/solo-io/envoy-gloo-ee/pull/663