### PR TITLE
Update Extensions Build Config to Pull in relocated xDS code extensions

### DIFF
--- a/.github/workflows/check-extensions-build-config.yaml
+++ b/.github/workflows/check-extensions-build-config.yaml
@@ -1,0 +1,24 @@
+name: check-extensions-build-config
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+jobs:
+  check-extensions-build-config:
+    name: check-extensions-build-config
+    runs-on: ubuntu-20.04-8core
+    steps:
+    - uses: actions/checkout@v3
+    - name: Add safe directory
+      run: git config --global --add safe.directory /__w/envoy-gloo-ee/envoy-gloo-ee
+    - name: Run check-extensions-build-config.sh
+      run: ci/check_extensions_build_config.sh
+    # - name: Archive check results
+      # if: ${{ !cancelled() }}
+      # uses: actions/upload-artifact@v3
+      # with:
+      #   name: static-analysis-report
+      #   path: linux/amd64/analysis/scan-build-*/

--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -386,6 +386,17 @@ EXTENSIONS = {
     "envoy.route.early_data_policy.default":           "//source/extensions/early_data:default_early_data_policy_lib",
 
     #
+    # Load balancing policies for upstream
+    #
+    "envoy.load_balancing_policies.least_request":     "//source/extensions/load_balancing_policies/least_request:config",
+    "envoy.load_balancing_policies.random":            "//source/extensions/load_balancing_policies/random:config",
+    "envoy.load_balancing_policies.round_robin":       "//source/extensions/load_balancing_policies/round_robin:config",
+    "envoy.load_balancing_policies.maglev":            "//source/extensions/load_balancing_policies/maglev:config",
+    "envoy.load_balancing_policies.ring_hash":         "//source/extensions/load_balancing_policies/ring_hash:config",
+    "envoy.load_balancing_policies.subset":            "//source/extensions/load_balancing_policies/subset:config",
+    "envoy.load_balancing_policies.cluster_provided":  "//source/extensions/load_balancing_policies/cluster_provided:config",
+
+    #
     # Config Subscription
     #
 

--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -188,6 +188,12 @@ EXTENSIONS = {
     #
 
     "envoy.filters.network.connection_limit":                     "//source/extensions/filters/network/connection_limit:config",
+    "envoy.filters.network.direct_response":                      "//source/extensions/filters/network/direct_response:config",
+    "envoy.filters.network.dubbo_proxy":                          "//source/extensions/filters/network/dubbo_proxy:config",
+    "envoy.filters.network.echo":                                 "//source/extensions/filters/network/echo:config",
+    "envoy.filters.network.ext_authz":                            "//source/extensions/filters/network/ext_authz:config",
+    "envoy.filters.network.http_connection_manager":              "//source/extensions/filters/network/http_connection_manager:config",
+    "envoy.filters.network.local_ratelimit":                      "//source/extensions/filters/network/local_ratelimit:config",
     "envoy.filters.network.mongo_proxy":                          "//source/extensions/filters/network/mongo_proxy:config",
     "envoy.filters.network.ratelimit":                            "//source/extensions/filters/network/ratelimit:config",
     "envoy.filters.network.rbac":                                 "//source/extensions/filters/network/rbac:config",
@@ -434,8 +440,10 @@ EXTENSIONS = {
     #
     "envoy.load_balancing_policies.least_request":     "//source/extensions/load_balancing_policies/least_request:config",
     "envoy.load_balancing_policies.random":            "//source/extensions/load_balancing_policies/random:config",
+    "envoy.load_balancing_policies.round_robin":       "//source/extensions/load_balancing_policies/round_robin:config",
     "envoy.load_balancing_policies.maglev":            "//source/extensions/load_balancing_policies/maglev:config",
     "envoy.load_balancing_policies.ring_hash":         "//source/extensions/load_balancing_policies/ring_hash:config",
+    "envoy.load_balancing_policies.subset":            "//source/extensions/load_balancing_policies/subset:config",
     "envoy.load_balancing_policies.cluster_provided":  "//source/extensions/load_balancing_policies/cluster_provided:config",
 
     #
@@ -452,6 +460,10 @@ EXTENSIONS = {
     "envoy.config_subscription.filesystem": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
     "envoy.config_subscription.filesystem_collection": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
     "envoy.config_subscription.grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
+    "envoy.config_subscription.delta_grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
+    "envoy.config_subscription.ads": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
+    "envoy.config_subscription.aggregated_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
+    "envoy.config_subscription.aggregated_delta_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
     "envoy.config_subscription.ads_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
     "envoy.config_mux.delta_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",
     "envoy.config_mux.sotw_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",

--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -188,12 +188,6 @@ EXTENSIONS = {
     #
 
     "envoy.filters.network.connection_limit":                     "//source/extensions/filters/network/connection_limit:config",
-    "envoy.filters.network.direct_response":                      "//source/extensions/filters/network/direct_response:config",
-    "envoy.filters.network.dubbo_proxy":                          "//source/extensions/filters/network/dubbo_proxy:config",
-    "envoy.filters.network.echo":                                 "//source/extensions/filters/network/echo:config",
-    "envoy.filters.network.ext_authz":                            "//source/extensions/filters/network/ext_authz:config",
-    "envoy.filters.network.http_connection_manager":              "//source/extensions/filters/network/http_connection_manager:config",
-    "envoy.filters.network.local_ratelimit":                      "//source/extensions/filters/network/local_ratelimit:config",
     "envoy.filters.network.mongo_proxy":                          "//source/extensions/filters/network/mongo_proxy:config",
     "envoy.filters.network.ratelimit":                            "//source/extensions/filters/network/ratelimit:config",
     "envoy.filters.network.rbac":                                 "//source/extensions/filters/network/rbac:config",
@@ -440,10 +434,8 @@ EXTENSIONS = {
     #
     "envoy.load_balancing_policies.least_request":     "//source/extensions/load_balancing_policies/least_request:config",
     "envoy.load_balancing_policies.random":            "//source/extensions/load_balancing_policies/random:config",
-    "envoy.load_balancing_policies.round_robin":       "//source/extensions/load_balancing_policies/round_robin:config",
     "envoy.load_balancing_policies.maglev":            "//source/extensions/load_balancing_policies/maglev:config",
     "envoy.load_balancing_policies.ring_hash":         "//source/extensions/load_balancing_policies/ring_hash:config",
-    "envoy.load_balancing_policies.subset":            "//source/extensions/load_balancing_policies/subset:config",
     "envoy.load_balancing_policies.cluster_provided":  "//source/extensions/load_balancing_policies/cluster_provided:config",
 
     #
@@ -460,10 +452,6 @@ EXTENSIONS = {
     "envoy.config_subscription.filesystem": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
     "envoy.config_subscription.filesystem_collection": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
     "envoy.config_subscription.grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
-    "envoy.config_subscription.delta_grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
-    "envoy.config_subscription.ads": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
-    "envoy.config_subscription.aggregated_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
-    "envoy.config_subscription.aggregated_delta_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
     "envoy.config_subscription.ads_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
     "envoy.config_mux.delta_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",
     "envoy.config_mux.sotw_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",

--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -388,17 +388,18 @@ EXTENSIONS = {
     #
     # Config Subscription
     #
-    # "envoy.config_subscription.rest": "//source/extensions/config_subscription/rest:http_subscription_lib",
-    # "envoy.config_subscription.filesystem": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
-    # "envoy.config_subscription.filesystem_collection": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
-    # "envoy.config_subscription.grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
-    # "envoy.config_subscription.delta_grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
-    # "envoy.config_subscription.ads": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
-    # "envoy.config_subscription.aggregated_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
-    # "envoy.config_subscription.aggregated_delta_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
-    # "envoy.config_subscription.ads_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
-    # "envoy.config_mux.delta_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",
-    # "envoy.config_mux.sotw_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",
+
+    "envoy.config_subscription.rest": "//source/extensions/config_subscription/rest:http_subscription_lib",
+    "envoy.config_subscription.filesystem": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
+    "envoy.config_subscription.filesystem_collection": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
+    "envoy.config_subscription.grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
+    "envoy.config_subscription.delta_grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
+    "envoy.config_subscription.ads": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
+    "envoy.config_subscription.aggregated_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
+    "envoy.config_subscription.aggregated_delta_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
+    "envoy.config_subscription.ads_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
+    "envoy.config_mux.delta_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",
+    "envoy.config_mux.sotw_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",
 }
 
 # These can be changed to ["//visibility:public"], for  downstream builds which

--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -384,6 +384,21 @@ EXTENSIONS = {
     #
 
     "envoy.route.early_data_policy.default":           "//source/extensions/early_data:default_early_data_policy_lib",
+
+    #
+    # Config Subscription
+    #
+    # "envoy.config_subscription.rest": "//source/extensions/config_subscription/rest:http_subscription_lib",
+    # "envoy.config_subscription.filesystem": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
+    # "envoy.config_subscription.filesystem_collection": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
+    # "envoy.config_subscription.grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
+    # "envoy.config_subscription.delta_grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
+    # "envoy.config_subscription.ads": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",
+    # "envoy.config_subscription.aggregated_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
+    # "envoy.config_subscription.aggregated_delta_grpc_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
+    # "envoy.config_subscription.ads_collection": "//source/extensions/config_subscription/grpc:grpc_collection_subscription_lib",
+    # "envoy.config_mux.delta_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",
+    # "envoy.config_mux.sotw_grpc_mux_factory": "//source/extensions/config_subscription/grpc/xds_mux:grpc_mux_lib",
 }
 
 # These can be changed to ["//visibility:public"], for  downstream builds which

--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -62,9 +62,16 @@ EXTENSIONS = {
     #
 
     "envoy.health_checkers.redis":                      "//source/extensions/health_checkers/redis:config",
+    # "envoy.health_checkers.thrift":                     "//source/extensions/health_checkers/thrift:config",
     "envoy.health_checkers.tcp":                        "//source/extensions/health_checkers/tcp:health_checker_lib",
     "envoy.health_checkers.http":                       "//source/extensions/health_checkers/http:health_checker_lib",
     "envoy.health_checkers.grpc":                       "//source/extensions/health_checkers/grpc:health_checker_lib",
+
+    #
+    # Health check event sinks
+    #
+
+    # "envoy.health_check.event_sinks.file":              "//source/extensions/health_check/event_sinks/file:file_sink_lib",
 
     #
     # Input Matchers
@@ -72,6 +79,8 @@ EXTENSIONS = {
 
     "envoy.matching.matchers.consistent_hashing":       "//source/extensions/matching/input_matchers/consistent_hashing:config",
     "envoy.matching.matchers.ip":                       "//source/extensions/matching/input_matchers/ip:config",
+    "envoy.matching.matchers.runtime_fraction":         "//source/extensions/matching/input_matchers/runtime_fraction:config",
+    "envoy.matching.matchers.cel_matcher":              "//source/extensions/matching/input_matchers/cel_matcher:config",
 
     #
     # Network Matchers
@@ -95,6 +104,17 @@ EXTENSIONS = {
     "envoy.matching.common_inputs.environment_variable":       "//source/extensions/matching/common_inputs/environment_variable:config",
 
     #
+    # CEL Matching Input
+    #
+    # "envoy.matching.inputs.cel_data_input":             "//source/extensions/matching/http/cel_input:cel_input_lib",
+
+    #
+    # Matching actions
+    #
+
+    # "envoy.matching.actions.format_string":             "//source/extensions/matching/actions/format_string:config",
+
+    #
     # HTTP filters
     #
 
@@ -110,7 +130,9 @@ EXTENSIONS = {
     "envoy.filters.http.compressor":                    "//source/extensions/filters/http/compressor:config",
     "envoy.filters.http.cors":                          "//source/extensions/filters/http/cors:config",
     "envoy.filters.http.composite":                     "//source/extensions/filters/http/composite:config",
+    # "envoy.filters.http.connect_grpc_bridge":           "//source/extensions/filters/http/connect_grpc_bridge:config",
     "envoy.filters.http.csrf":                          "//source/extensions/filters/http/csrf:config",
+    # "envoy.filters.http.custom_response":               "//source/extensions/filters/http/custom_response:factory",
     "envoy.filters.http.decompressor":                  "//source/extensions/filters/http/decompressor:config",
     "envoy.filters.http.dynamic_forward_proxy":         "//source/extensions/filters/http/dynamic_forward_proxy:config",
     "envoy.filters.http.ext_authz":                     "//source/extensions/filters/http/ext_authz:config",
@@ -118,6 +140,8 @@ EXTENSIONS = {
     "envoy.filters.http.fault":                         "//source/extensions/filters/http/fault:config",
     "envoy.filters.http.file_system_buffer":            "//source/extensions/filters/http/file_system_buffer:config",
     "envoy.filters.http.gcp_authn":                     "//source/extensions/filters/http/gcp_authn:config",
+    # "envoy.filters.http.geoip":                     "//source/extensions/filters/http/geoip:config",
+    # "envoy.filters.http.grpc_field_extraction":         "//source/extensions/filters/http/grpc_field_extraction:config",
     "envoy.filters.http.grpc_http1_bridge":             "//source/extensions/filters/http/grpc_http1_bridge:config",
     "envoy.filters.http.grpc_http1_reverse_bridge":     "//source/extensions/filters/http/grpc_http1_reverse_bridge:config",
     "envoy.filters.http.grpc_json_transcoder":          "//source/extensions/filters/http/grpc_json_transcoder:config",
@@ -127,6 +151,7 @@ EXTENSIONS = {
     "envoy.filters.http.health_check":                  "//source/extensions/filters/http/health_check:config",
     "envoy.filters.http.ip_tagging":                    "//source/extensions/filters/http/ip_tagging:config",
     "envoy.filters.http.jwt_authn":                     "//source/extensions/filters/http/jwt_authn:config",
+    # "envoy.filters.http.rate_limit_quota":              "//source/extensions/filters/http/rate_limit_quota:config",
     # Disabled by default
     "envoy.filters.http.kill_request":                  "//source/extensions/filters/http/kill_request:kill_request_config",
     "envoy.filters.http.local_ratelimit":               "//source/extensions/filters/http/local_ratelimit:config",
@@ -141,12 +166,14 @@ EXTENSIONS = {
     "envoy.filters.http.tap":                           "//source/extensions/filters/http/tap:config",
     "envoy.filters.http.wasm":                          "//source/extensions/filters/http/wasm:config",
     "envoy.filters.http.stateful_session":              "//source/extensions/filters/http/stateful_session:config",
+    # "envoy.filters.http.header_mutation":               "//source/extensions/filters/http/header_mutation:config",
 
     #
     # Listener filters
     #
 
     "envoy.filters.listener.http_inspector":            "//source/extensions/filters/listener/http_inspector:config",
+    # "envoy.filters.listener.local_ratelimit":           "//source/extensions/filters/listener/local_ratelimit:config",
     # NOTE: The original_dst filter is implicitly loaded if original_dst functionality is
     #       configured on the listener. Do not remove it in that case or configs will fail to load.
     "envoy.filters.listener.original_dst":              "//source/extensions/filters/listener/original_dst:config",
@@ -191,6 +218,7 @@ EXTENSIONS = {
 
     "envoy.resource_monitors.fixed_heap":               "//source/extensions/resource_monitors/fixed_heap:config",
     "envoy.resource_monitors.injected_resource":        "//source/extensions/resource_monitors/injected_resource:config",
+    # "envoy.resource_monitors.downstream_connections":   "//source/extensions/resource_monitors/downstream_connections:config",
 
     #
     # Stat sinks
@@ -200,6 +228,7 @@ EXTENSIONS = {
     "envoy.stat_sinks.graphite_statsd":                 "//source/extensions/stat_sinks/graphite_statsd:config",
     "envoy.stat_sinks.hystrix":                         "//source/extensions/stat_sinks/hystrix:config",
     "envoy.stat_sinks.metrics_service":                 "//source/extensions/stat_sinks/metrics_service:config",
+    # "envoy.stat_sinks.open_telemetry":                  "//source/extensions/stat_sinks/open_telemetry:config",
     "envoy.stat_sinks.statsd":                          "//source/extensions/stat_sinks/statsd:config",
     "envoy.stat_sinks.wasm":                            "//source/extensions/stat_sinks/wasm:config",
 
@@ -209,6 +238,7 @@ EXTENSIONS = {
 
     "envoy.filters.thrift.router":                      "//source/extensions/filters/network/thrift_proxy/router:config",
     "envoy.filters.thrift.header_to_metadata":          "//source/extensions/filters/network/thrift_proxy/filters/header_to_metadata:config",
+    # "envoy.filters.thrift.payload_to_metadata":         "//source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata:config",    
     "envoy.filters.thrift.rate_limit":                  "//source/extensions/filters/network/thrift_proxy/filters/ratelimit:config",
 
     #
@@ -253,6 +283,7 @@ EXTENSIONS = {
     #
     # CacheFilter plugins
     #
+    # "envoy.extensions.http.cache.file_system_http_cache": "//source/extensions/http/cache/file_system_http_cache:config",
     "envoy.extensions.http.cache.simple":               "//source/extensions/http/cache/simple_http_cache:config",
 
     #
@@ -269,6 +300,7 @@ EXTENSIONS = {
 
     "envoy.upstreams.http.http":                        "//source/extensions/upstreams/http/http:config",
     "envoy.upstreams.http.tcp":                         "//source/extensions/upstreams/http/tcp:config",
+    # "envoy.upstreams.http.udp":                         "//source/extensions/upstreams/http/udp:config",
 
     #
     # Watchdog actions
@@ -323,13 +355,24 @@ EXTENSIONS = {
     #
 
     "envoy.http.stateful_session.cookie":                "//source/extensions/http/stateful_session/cookie:config",
+    # "envoy.http.stateful_session.header":                "//source/extensions/http/stateful_session/header:config",
+
+    #
+    # Custom response policies
+    #
+
+    # "envoy.http.custom_response.redirect_policy":             "//source/extensions/http/custom_response/redirect_policy:redirect_policy_lib",
+    # "envoy.http.custom_response.local_response_policy":       "//source/extensions/http/custom_response/local_response_policy:local_response_policy_lib",
 
     #
     # QUIC extensions
     #
 
+    #"envoy.quic.deterministic_connection_id_generator": "//source/extensions/quic/connection_id_generator:envoy_deterministic_connection_id_generator_config",
     "envoy.quic.crypto_stream.server.quiche":           "//source/extensions/quic/crypto_stream:envoy_quic_default_crypto_server_stream",
     "envoy.quic.proof_source.filter_chain":             "//source/extensions/quic/proof_source:envoy_quic_default_proof_source",
+    #"envoy.quic.server_preferred_address.fixed":        "//source/extensions/quic/server_preferred_address:fixed_server_preferred_address_config_factory_config",
+
 
     #
     # UDP packet writers
@@ -341,6 +384,7 @@ EXTENSIONS = {
     # Formatter
     #
 
+    # "envoy.formatter.cel":                              "//source/extensions/formatter/cel:config",
     "envoy.formatter.metadata":                         "//source/extensions/formatter/metadata:config",
     "envoy.formatter.req_without_query":                "//source/extensions/formatter/req_without_query:config",
 
@@ -380,6 +424,12 @@ EXTENSIONS = {
     "envoy.http.header_validators.envoy_default":        "//source/extensions/http/header_validators/envoy_default:config",
 
     #
+    # Path Pattern Match and Path Pattern Rewrite
+    #
+    # "envoy.path.match.uri_template.uri_template_matcher": "//source/extensions/path/match/uri_template:config",
+    # "envoy.path.rewrite.uri_template.uri_template_rewriter": "//source/extensions/path/rewrite/uri_template:config",
+
+    #
     # Early Data option
     #
 
@@ -395,6 +445,12 @@ EXTENSIONS = {
     "envoy.load_balancing_policies.ring_hash":         "//source/extensions/load_balancing_policies/ring_hash:config",
     "envoy.load_balancing_policies.subset":            "//source/extensions/load_balancing_policies/subset:config",
     "envoy.load_balancing_policies.cluster_provided":  "//source/extensions/load_balancing_policies/cluster_provided:config",
+
+    #
+    # HTTP Early Header Mutation
+    #
+    # "envoy.http.early_header_mutation.header_mutation": "//source/extensions/http/early_header_mutation/header_mutation:config",
+
 
     #
     # Config Subscription

--- a/changelog/v1.27.1-patch3/update-extensions-build-config.yaml
+++ b/changelog/v1.27.1-patch3/update-extensions-build-config.yaml
@@ -4,3 +4,7 @@ changelog:
     Upstream moved xDs code extensions. In order to use these extensions, we have to 
     modify our extensions_build_config. See here:
     https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.27/v1.27.0
+- type: NON_USER_FACING
+  description: >-
+    Introduce check-extensions-build-config script and github action to ensure that
+    the extensions_build_config.bzl is up to date with the current envoy version.

--- a/changelog/v1.27.1-patch3/update-extensions-build-config.yaml
+++ b/changelog/v1.27.1-patch3/update-extensions-build-config.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Upstream moved xDs code extensions. In order to use these extensions, we have to 
+    modify our extensions_build_config. See here:
+    https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.27/v1.27.0

--- a/ci/check_extensions_build_config.sh
+++ b/ci/check_extensions_build_config.sh
@@ -50,6 +50,12 @@ fi
 # Update the URL to point to the specific envoy commit
 UPSTREAM_URL="https://raw.githubusercontent.com/$UPSTREAM_REPO/$ENVOY_COMMIT_HASH/$UPSTREAM_FILE_PATH"
 
+curl -s "$UPSTREAM_URL" -o upstream_file.tmp
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to fetch the upstream file from $UPSTREAM_URL"
+    exit 1
+fi
+
 # Initialize arrays to store the upstream and envoy-gloo versions of the file
 declare -a UPSTREAM_LINES ENVOY_GLOO_LINES
 

--- a/ci/check_extensions_build_config.sh
+++ b/ci/check_extensions_build_config.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+########################
+### Helper functions ###
+########################
+
+# Define the upstream repository and file path
+UPSTREAM_REPO="envoyproxy/envoy"
+UPSTREAM_FILE_PATH="source/extensions/extensions_build_config.bzl"
+UPSTREAM_URL="https://raw.githubusercontent.com/$UPSTREAM_REPO/main/$UPSTREAM_FILE_PATH"
+
+# Define the path to the local version
+ENVOY_GLOO_FILE="./bazel/extensions/extensions_build_config.bzl"
+
+# Function to trim leading and trailing whitespaces
+trim() {
+    local var="$*"
+    var="${var#"${var%%[![:space:]]*}"}"   # remove leading whitespace characters
+    var="${var%"${var##*[![:space:]]}"}"   # remove trailing whitespace characters
+    echo -n "$var"
+}
+
+# Function to report an error
+report_error() {
+    local line_number=$1
+    local line_content="$2"
+    local github_line_url="https://github.com/$UPSTREAM_REPO/blob/main/$UPSTREAM_FILE_PATH#L$line_number"
+    echo "Error: Line not found in the envoy-gloo version of extensions_build_config.bzl at line $line_number\n\t$line_content\n\tSee: $github_line_url"
+}
+
+########################
+#### Main execution ####
+########################
+
+# Initialize arrays to store the upstream and envoy-gloo versions of the file
+declare -a UPSTREAM_LINES ENVOY_GLOO_LINES
+
+# Read the upstream version of the file into an array
+curl -s "$UPSTREAM_URL" -o upstream_file.tmp
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to fetch the upstream file from $UPSTREAM_URL"
+    exit 1
+fi
+IFS=$'\n' read -r -d '' -a UPSTREAM_LINES < upstream_file.tmp
+
+# Check if the envoy-gloo file exists and is readable
+if [ ! -r "$ENVOY_GLOO_FILE" ]; then
+    echo "Error: The envoy-gloo file $ENVOY_GLOO_FILE does not exist or is not readable"
+    exit 1
+fi
+IFS=$'\n' read -r -d '' -a ENVOY_GLOO_LINES < "$ENVOY_GLOO_FILE"
+
+# Preprocess the envoy-gloo lines for faster lookup
+declare -a PROCESSED_ENVOY_GLOO_LINES
+for line in "${ENVOY_GLOO_LINES[@]}"; do
+    trimmed_line=$(trim "${line##\#}")
+    PROCESSED_ENVOY_GLOO_LINES+=("$trimmed_line")
+done
+
+# Flag to track if any issues are found
+ISSUES_FOUND=false
+ERRORS=()
+
+# Loop through each line in the upstream version
+LINE_NUMBER=0
+for UPSTREAM_LINE in "${UPSTREAM_LINES[@]}"; do
+    ((LINE_NUMBER++))
+    TRIMMED_UPSTREAM_LINE=$(trim "$UPSTREAM_LINE")
+
+    # Skip if the line is empty or a comment
+    if [[ -z "$TRIMMED_UPSTREAM_LINE" || "$TRIMMED_UPSTREAM_LINE" =~ ^# ]]; then
+        continue
+    fi
+
+    # Reject any lines that don't match the format "key": "value". 
+    # Additional spaces around the colon and any content within the quotes are allowed.
+    if ! [[ "$TRIMMED_UPSTREAM_LINE" =~ ^[^\"]*\"[^\"]*\":\ *\"[^\"]*\" ]]; then
+        continue
+    fi
+
+    # Check if the trimmed line exists in the processed envoy-gloo lines
+    LINE_FOUND=false
+    for PROCESSED_LINE in "${PROCESSED_ENVOY_GLOO_LINES[@]}"; do
+        if [[ "$PROCESSED_LINE" == "$TRIMMED_UPSTREAM_LINE" ]]; then
+            LINE_FOUND=true
+            break
+        fi
+    done
+
+    if [ "$LINE_FOUND" = false ]; then
+        ERRORS+=("$(report_error "$LINE_NUMBER" "$UPSTREAM_LINE")")
+        ISSUES_FOUND=true
+    fi
+done
+
+# Check if any issues were found
+if [ "$ISSUES_FOUND" = true ]; then
+    for err in "${ERRORS[@]}"; do
+        echo -e "$err"
+    done
+    echo "Envoy-gloo extensions_build_config.bzl is not up to date with the upstream version."
+    exit 1
+else
+    echo "Envoy-gloo extensions_build_config.bzl is up to date with the upstream version."
+fi
+
+# Cleanup
+rm upstream_file.tmp

--- a/ci/check_extensions_build_config.sh
+++ b/ci/check_extensions_build_config.sh
@@ -68,7 +68,12 @@ done < "$ENVOY_GLOO_FILE"
 # Preprocess the envoy-gloo lines for faster lookup
 declare -a PROCESSED_ENVOY_GLOO_LINES
 for line in "${ENVOY_GLOO_LINES[@]}"; do
-    trimmed_line=$(trim "${line##\#}")
+    # Remove only the first leading '#' character (if present) and any spaces before it
+    trimmed_line=$(echo "$line" | sed 's/^[[:space:]]*#//')
+
+    # remove any remaining whitespace
+    trimmed_line=$(trim "$trimmed_line")
+
     PROCESSED_ENVOY_GLOO_LINES+=("$trimmed_line")
 done
 

--- a/ci/check_extensions_build_config.sh
+++ b/ci/check_extensions_build_config.sh
@@ -4,13 +4,21 @@
 ### Helper functions ###
 ########################
 
-# Define the upstream repository and file path
+# Define the upstream repository and file path to the upstream extensions_build_config.bzl
 UPSTREAM_REPO="envoyproxy/envoy"
 UPSTREAM_FILE_PATH="source/extensions/extensions_build_config.bzl"
-UPSTREAM_URL="https://raw.githubusercontent.com/$UPSTREAM_REPO/main/$UPSTREAM_FILE_PATH"
-
+# Define the path to the local repository_locations.bzl, which contains the envoy commit hash
+REPOSITORY_LOCATIONS_FILE="./bazel/repository_locations.bzl"
 # Define the path to the local version
 ENVOY_GLOO_FILE="./bazel/extensions/extensions_build_config.bzl"
+
+# Function to extract the envoy commit hash from repository_locations.bzl
+get_envoy_commit_hash() {
+    local file_path="$1"
+    local commit_hash
+    commit_hash=$(grep -A 2 "envoy =" "$file_path" | grep commit | cut -d '"' -f 2)
+    echo "$commit_hash"
+}
 
 # Function to trim leading and trailing whitespaces
 trim() {
@@ -24,7 +32,7 @@ trim() {
 report_error() {
     local line_number=$1
     local line_content="$2"
-    local github_line_url="https://github.com/$UPSTREAM_REPO/blob/main/$UPSTREAM_FILE_PATH#L$line_number"
+    local github_line_url="https://github.com/$UPSTREAM_REPO/blob/$ENVOY_COMMIT_HASH/$UPSTREAM_FILE_PATH#L$line_number"
     echo "Error: Line not found in the envoy-gloo version of extensions_build_config.bzl at line $line_number\n\t$line_content\n\tSee: $github_line_url"
 }
 
@@ -32,23 +40,30 @@ report_error() {
 #### Main execution ####
 ########################
 
+# Extract the envoy commit hash
+ENVOY_COMMIT_HASH=$(get_envoy_commit_hash "$REPOSITORY_LOCATIONS_FILE")
+if [ -z "$ENVOY_COMMIT_HASH" ]; then
+    echo "Error: Failed to extract envoy commit hash from $REPOSITORY_LOCATIONS_FILE"
+    exit 1
+fi
+
+# Update the URL to point to the specific envoy commit
+UPSTREAM_URL="https://raw.githubusercontent.com/$UPSTREAM_REPO/$ENVOY_COMMIT_HASH/$UPSTREAM_FILE_PATH"
+
 # Initialize arrays to store the upstream and envoy-gloo versions of the file
 declare -a UPSTREAM_LINES ENVOY_GLOO_LINES
 
-# Read the upstream version of the file into an array
-curl -s "$UPSTREAM_URL" -o upstream_file.tmp
-if [ $? -ne 0 ]; then
-    echo "Error: Failed to fetch the upstream file from $UPSTREAM_URL"
-    exit 1
-fi
-IFS=$'\n' read -r -d '' -a UPSTREAM_LINES < upstream_file.tmp
+# Read the upstream version of the file into an array, including empty lines
+UPSTREAM_LINES=()
+while IFS= read -r line || [[ -n "$line" ]]; do
+    UPSTREAM_LINES+=("$line")
+done < upstream_file.tmp
 
-# Check if the envoy-gloo file exists and is readable
-if [ ! -r "$ENVOY_GLOO_FILE" ]; then
-    echo "Error: The envoy-gloo file $ENVOY_GLOO_FILE does not exist or is not readable"
-    exit 1
-fi
-IFS=$'\n' read -r -d '' -a ENVOY_GLOO_LINES < "$ENVOY_GLOO_FILE"
+# Read the envoy-gloo version of the file into an array, including empty lines
+ENVOY_GLOO_LINES=()
+while IFS= read -r line || [[ -n "$line" ]]; do
+    ENVOY_GLOO_LINES+=("$line")
+done < "$ENVOY_GLOO_FILE"
 
 # Preprocess the envoy-gloo lines for faster lookup
 declare -a PROCESSED_ENVOY_GLOO_LINES

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -26,15 +26,6 @@ steps:
   secretEnv:
   - 'GCP_SERVICE_ACCOUNT_KEY'
 
-- name: gcr.io/cloud-builders/gsutil
-  entrypoint: 'bash'
-  args:
-  - '-ec'
-  - |
-    ci/check_extensions_build_config.sh
-  id: 'check-extensions-build-config'
-
-
 - name: 'gcr.io/cloud-builders/docker'
   id: 'docker-release'
   entrypoint: 'bash'

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -26,6 +26,15 @@ steps:
   secretEnv:
   - 'GCP_SERVICE_ACCOUNT_KEY'
 
+- name: gcr.io/cloud-builders/gsutil
+  entrypoint: 'bash'
+  args:
+  - '-ec'
+  - |
+    ci/check_extensions_build_config.sh
+  id: 'check-extensions-build-config'
+
+
 - name: 'gcr.io/cloud-builders/docker'
   id: 'docker-release'
   entrypoint: 'bash'


### PR DESCRIPTION
# Description
 - As described in the envoy 1.27.0 changelog, upstream has moved xDS code extensions. Because Gloo Edge relies on xDS, we need to explicitly include these extensions
 - https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.27/v1.27.0
 - In practice, this means that envoy-gloo crashes when it is provided config which specifies the `ads_config` field. The bootstrap config provided by Gloo Edge always includes this field, so this change is necessary to make envoy-gloo v1.27 compatible with Gloo Edge

# Testing
 - I tested this by running Envoy with a simple config that specifies the `ads_config` field. On v1.27.1-patch2, this causes envoy to crash. 
 - I will run the envoy binary created by this PR's CI against the same config. I expect it to behave normally
 - The specific config I used is:
```yaml
admin:
  access_log_path: /dev/stdout
  address:
    socket_address:
      address: 0.0.0.0
      port_value: 19000
static_resources:
  listeners:
  - name: listener_0
    address:
      socket_address: { address: 0.0.0.0, port_value: 10000 }
    filter_chains:
    - filters:
      - name: envoy.filters.network.http_connection_manager
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
          stat_prefix: http
          codec_type: AUTO
          route_config:
            name: local_route
            virtual_hosts:
            - name: local_service
              domains: ["*"]
              routes:
              - match:
                  prefix: /echo
                route:
                  cluster: postman-echo
                  prefix_rewrite: /post
          http_filters:
          - name: envoy.filters.http.router
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
  clusters:
  - connect_timeout: 5.000s
    load_assignment:
      cluster_name: postman-echo
      endpoints:
      - lb_endpoints:
        - endpoint:
            address:
              socket_address:
                address: httpbin.org
                port_value: 443
    name: postman-echo
    type: LOGICAL_DNS
    transport_socket:
      name: envoy.transport_sockets.tls
      typed_config:
        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
dynamic_resources:
  ads_config:
    transport_api_version: V3
    api_type: GRPC
    rate_limit_settings: {}
    grpc_services:
    - envoy_grpc: {cluster_name: gloo.gloo-system.svc.cluster.local:9977}
  cds_config:
    resource_api_version: V3
    ads: {}
  lds_config:
    resource_api_version: V3
    ads: {}
```