### PR TITLE
[1.27/main] Switch to envoy-fork

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,8 +1,10 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
-        # envoy 1.27.1
-        commit = "6b9db09c69965d5bfb37bdd29693f8b7f9e9e9ec",
-        remote = "https://github.com/envoyproxy/envoy",
+        # envoy 1.27.1 forked with extproc changes
+        # sourced from release/v1.27-backportedfork
+        # should go back to upstream once 1.29 or wherever the associated (extproc + tap) prs are merged
+        commit = "dcf8bfb08a20fbbb4f4dd479d1e2bf6747b9f206",
+        remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(
         # Includes unmerged modifications for

--- a/changelog/v1.27.1-patch4/bump-fork-1.27.yaml
+++ b/changelog/v1.27.1-patch4/bump-fork-1.27.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-fork
+  dependencyTag: dcf8bfb08a20fbbb4f4dd479d1e2bf6747b9f206
+  description: >
+    Update envoy dep to point to 1.27-backportedfork branch on solo-io/envoy-fork.
+    This branch contains backports of tap and ext-proc work which are not yet in envoyproxy/envoy.


### PR DESCRIPTION
# Description
 - Update envoy dep to point to `1.27-backportedfork` branch on solo-io/envoy-fork.
 - This branch contains backports of tap and ext-proc work which are not yet in envoyproxy/envoy.