### PR TITLE
[DNM] Remove rest config subscription

### DIFF
--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -456,7 +456,7 @@ EXTENSIONS = {
     # Config Subscription
     #
 
-    "envoy.config_subscription.rest": "//source/extensions/config_subscription/rest:http_subscription_lib",
+    # "envoy.config_subscription.rest": "//source/extensions/config_subscription/rest:http_subscription_lib",
     "envoy.config_subscription.filesystem": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
     "envoy.config_subscription.filesystem_collection": "//source/extensions/config_subscription/filesystem:filesystem_subscription_lib",
     "envoy.config_subscription.grpc": "//source/extensions/config_subscription/grpc:grpc_subscription_lib",


### PR DESCRIPTION
# Description
 - DNM
 - I have created this PR so I can get a working build of envoy-gloo 1.27 which does not opt-in to the REST config subscription extension.