### PR TITLE
add creds for build cache

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -42,7 +42,7 @@ export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test
 export ENVOY_CONTRIB_BUILD_TARGET="//source/exe:envoy-static"
 export ENVOY_CONTRIB_BUILD_DEBUG_INFORMATION="//source/exe:envoy-static.dwp"
 
-BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} --remote_cache=${BAZEL_REMOTE_CACHE}"
+BAZEL_BUILD_EXTRA_OPTIONS+=" ${BAZEL_BUILD_EXTRA_OPTIONS} --remote_cache=${BAZEL_REMOTE_CACHE}"
 
 export  GCP_SERVICE_ACCOUNT_KEY_PATH=$(mktemp -t gcp_service_account.XXXXXX.json)
 echo "${GCP_SERVICE_ACCOUNT_KEY}" | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_PATH}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -42,6 +42,12 @@ export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test
 export ENVOY_CONTRIB_BUILD_TARGET="//source/exe:envoy-static"
 export ENVOY_CONTRIB_BUILD_DEBUG_INFORMATION="//source/exe:envoy-static.dwp"
 
+BAZEL_BUILD_EXTRA_OPTIONS="${BAZEL_BUILD_EXTRA_OPTIONS} --remote_cache=${BAZEL_REMOTE_CACHE}"
+
+export  GCP_SERVICE_ACCOUNT_KEY_PATH=$(mktemp -t gcp_service_account.XXXXXX.json)
+echo "${GCP_SERVICE_ACCOUNT_KEY}" | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_PATH}"
+BAZEL_BUILD_EXTRA_OPTIONS+=" --google_credentials=${GCP_SERVICE_ACCOUNT_KEY_PATH}"
+
 if [ "${BUILD_TYPE:-}" != "" ] ; then
   BUILD_CONFIG="--config=$BUILD_TYPE"
 fi

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -42,7 +42,7 @@ export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test
 export ENVOY_CONTRIB_BUILD_TARGET="//source/exe:envoy-static"
 export ENVOY_CONTRIB_BUILD_DEBUG_INFORMATION="//source/exe:envoy-static.dwp"
 
-BAZEL_BUILD_EXTRA_OPTIONS+=" ${BAZEL_BUILD_EXTRA_OPTIONS} --remote_cache=${BAZEL_REMOTE_CACHE}"
+BAZEL_BUILD_EXTRA_OPTIONS+=" --remote_cache=${BAZEL_REMOTE_CACHE}"
 
 export  GCP_SERVICE_ACCOUNT_KEY_PATH=$(mktemp -t gcp_service_account.XXXXXX.json)
 echo "${GCP_SERVICE_ACCOUNT_KEY}" | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_PATH}"


### PR DESCRIPTION
Open source companion to  https://github.com/solo-io/envoy-gloo-ee/pull/746
One change here is identical to those from that PR:
> The method we were hooking into for setting the build cache creds was deprecated in [this PR](https://github.com/envoyproxy/envoy/pull/30211/files#diff-8ad500a48b7168360d58c77bf8dee4fd26953e800b0b09aa5742f744b537b7deR17-R23) and removed entirely in [this PR](https://github.com/envoyproxy/envoy/pull/30261).

> This PR takes the creds management added to some of the azure actions in the latter linked PR and adapts it for use in our own `do_ci.sh`. 

In addition, this PR exports `BAZEL_BUILD_EXTRA_OPTIONS`, explicitly setting the `--remote-cache` bazel flag to the value of `BAZEL_REMOTE_CACHE`, which is currently set by `ci/cloudbuild.yaml`

As you can see in the first PR linked above, this change is also necessary to ensure that envoy-gloo CI targets the proper remote cache URL

```sh
    echo "Setting BAZEL_REMOTE_CACHE is deprecated, please use BAZEL_BUILD_EXTRA_OPTIONS " \
         "or use a user.bazelrc config " >&2
```