### PR TITLE
Use private pool cloud build worker

### DIFF
--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -63,7 +63,7 @@ artifacts:
     paths: ['linux/amd64/build_envoy_release/envoy']
 
 tags:
-  - "envoy-gloo"
+  - "repo_envoy-gloo"
 
 availableSecrets:
   inline:

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -64,6 +64,11 @@ artifacts:
 
 tags:
   - "repo_envoy-gloo"
+  # This tag can be used to filter for or out jobs which are spawned by the main job
+  # submitted by build-bot. It's somewhat redundant as one could filter on `tags~^pr`
+  # to achieve the same effect since that tag is added to main jobs by build-bot,
+  # but this is somewhat less esoteric
+  - "sub-job"
 
 availableSecrets:
   inline:

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -53,13 +53,17 @@ steps:
   - 'TAGGED_VERSION=$TAG_NAME'
 
 options:
-  machineType: 'N1_HIGHCPU_32'
+  pool:
+    name: 'projects/solo-public/locations/us-central1/workerPools/envoy-gloo-runner'
 timeout: 20000s
 
 artifacts:
   objects:
     location: 'gs://solo-public-artifacts.solo.io/envoy/$COMMIT_SHA/'
     paths: ['linux/amd64/build_envoy_release/envoy']
+
+tags:
+  - "envoy-gloo"
 
 availableSecrets:
   inline:

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -33,12 +33,8 @@ fi
 
 export ENVOY_SRCDIR=$SOURCE_DIR
 
-# google cloud build times out when using full throttle.
-# additionally, we see builds killed due to OOM at high concurrency.
-export NUM_CPUS=10
-
 # google cloud build doesn't like ipv6
-export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors --jobs=${NUM_CPUS}"
+export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors"
 
 # We do not need/want to build the Envoy contrib filters so we replace the
 # associated targets with the ENVOY_BUILD values

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,14 @@
 steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['builds','submit','--config=ci/cloudbuild.yaml','--substitutions','TAG_NAME=$TAG_NAME,COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=']
+  id: "standard"
+  args: ['builds','submit','--region=us-central1','--config=ci/cloudbuild.yaml','--substitutions','TAG_NAME=$TAG_NAME,COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=']
 
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['builds','submit','--config=ci/cloudbuild.yaml','--substitutions','COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=clang-asan']
+  id: "asan"
+  args: ['builds','submit','--region=us-central1','--config=ci/cloudbuild.yaml','--substitutions','COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=clang-asan']
   waitFor: ['-']
 
+tags:
+  - "envoy-gloo"
 timeout: 20000s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,4 @@ steps:
   args: ['builds','submit','--region=us-central1','--config=ci/cloudbuild.yaml','--substitutions','COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=clang-asan']
   waitFor: ['-']
 
-tags:
-  - "envoy-gloo"
 timeout: 20000s


### PR DESCRIPTION
These changes are part of the initiative to reduce flaking due to runners killing the processfor lack of memory. The investigation can be found [here](https://docs.google.com/document/d/1e-kpbV1mkSUnOiWFdn5xGcOfFZo-Sr4lcUIFhLmjpx0/edit?pli=1).