### PR TITLE
Fix Path Discrepancy in Release Binary Extraction

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -62,7 +62,7 @@ bash -x "$UPSTREAM_ENVOY_SRCDIR/ci/do_ci.sh" "$@"
 echo Extracting release binaries
 ENVOY_GLOO_BIN_DIR='linux/amd64/build_envoy_release'
 mkdir -p "$ENVOY_GLOO_BIN_DIR"
-bazel run @envoy//tools/zstd:zstd -- --stdout -d /build/envoy/x64/bin/release.tar.zst \
+bazel run @envoy//tools/zstd:zstd -- --stdout -d /build/envoy/arm64/bin/release.tar.zst \
     | tar xfO - envoy > "$ENVOY_GLOO_BIN_DIR/envoy"
 
 chmod +x "${ENVOY_GLOO_BIN_DIR}/envoy"


### PR DESCRIPTION
### Description
This PR addresses an issue in the Envoy-Gloo build script where there is a path discrepancy in extracting the `release.tar.zst` file. The current script attempts to extract from `/build/envoy/x64/bin/release.tar.zst`, whereas the file is actually located at `/build/envoy/arm64/bin/release.tar.zst`. This PR updates the script to use the correct path.

### Overview of Changes
- Updated the extraction path in the build script from `/build/envoy/x64/bin/release.tar.zst` to `/build/envoy/arm64/bin/release.tar.zst`.
- Ensured the updated path aligns with the actual location of the `release.tar.zst` file as created by the build process.

### Context and Background
- The discrepancy in the path was causing an extraction error as the script couldn't locate the file.

### Testing and Validation
- In order to test the issue you should run `./ci/run_envoy_docker.sh 'ci/do_ci.sh bazel.release.server_only'`
The expected errors are the following:
```
INFO: Build completed successfully, 5 total actions
+ cp -a bazel-bin/distribution/binary/release.tar.zst /build/envoy/arm64/bin/release.tar.zst
+ bazel build --repository_cache=/build/repository_cache --experimental_repository_cache_hardlinks --verbose_failures --experimental_generate_json_trace_profile --test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors --jobs=10 --test_env=HEAPCHECK= --test_tmpdir=/build/tmp --config=libc++ --stripopt=--strip-all -c opt --remote_download_toplevel //test/tools/schema_validator:schema_validator_tool.stripped
+ local startup_options
+ read -ra startup_options
+ /usr/local/bin/bazel --output_user_root=/build/bazel_root --output_base=/build/bazel_root/base build --repository_cache=/build/repository_cache --experimental_repository_cache_hardlinks --verbose_failures --experimental_generate_json_trace_profile --test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors --jobs=10 --test_env=HEAPCHECK= --test_tmpdir=/build/tmp --config=libc++ --stripopt=--strip-all -c opt --remote_download_toplevel //test/tools/schema_validator:schema_validator_tool.stripped
WARNING: Duplicate rc file: /source/clang.bazelrc is imported multiple times from /source/.bazelrc
WARNING: The following configs were expanded more than once: [clang]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
WARNING: The following configs were expanded more than once: [clang]. For repeatable flags, repeats are counted twice and may lead to unexpected behavior.
INFO: Analyzed target //test/tools/schema_validator:schema_validator_tool.stripped (2 packages loaded, 6 targets configured).
INFO: Found 1 target...
Target //test/tools/schema_validator:schema_validator_tool.stripped up-to-date:
  bazel-bin/test/tools/schema_validator/schema_validator_tool.stripped
INFO: Elapsed time: 0.708s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
+ cp -a bazel-bin/test/tools/schema_validator/schema_validator_tool.stripped /build/envoy/arm64/bin/schema_validator_tool
+ echo 'Release files created in /build/envoy/arm64/bin'
Release files created in /build/envoy/arm64/bin
+ cleanup
+ rm -rf /source/bazel-bin /source/bazel-out /source/bazel-source /source/bazel-testlogs clang.bazelrc
Extracting release binaries
Loading:
Loading:
Loading: 1 packages loaded
Analyzing: target @envoy//tools/zstd:zstd (2 packages loaded, 0 targets configured)
INFO: Analyzed target @envoy//tools/zstd:zstd (127 packages loaded, 11506 targets configured).
 checking cached actions
INFO: Found 1 target...
[4 / 7] [Prepa] BazelWorkspaceStatusAction stable-status.txt
Target @envoy//tools/zstd:zstd up-to-date:
  bazel-bin/external/envoy/tools/zstd/zstd
INFO: Elapsed time: 2.350s, Critical Path: 0.11s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/external/envoy/tools/zstd/zstd --stdout -d /build/envoy/x64/bin/release.tar.zst
zstd: can't stat /build/envoy/x64/bin/release.tar.zst : No such file or directory -- ignored
tar: This does not look like a tar archive
tar: envoy: Not found in archive
tar: Exiting with failure status due to previous errors
```
