### PR TITLE
1.26 | bazel: Update to a newer version of envoy-fork with http2 continuation cve

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,8 +1,8 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
         # envoy 1.26.7 forked with extproc changes
-        # sourced from release v1.26.7-fork1
-        commit = "37f7ac716a3253001640ccb4a548d8dba0d6cf4f",
+        # sourced from release v1.26.8-fork1
+        commit = "f87a6143de75426bff63d0da4e9d4ed400b74a40",
         remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(

--- a/changelog/v1.26.8-patch1/envoy-bump.yaml
+++ b/changelog/v1.26.8-patch1/envoy-bump.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyRepo: envoy
+    dependencyOwner: envoyproxy
+    dependencyTag: v1.26.8
+    description: >
+      Bump Envoy to v1.26.8 for our fork.
+      Tackles the http2 crazy cve CVE-2024-30255

--- a/changelog/v1.26.8-patch1/envoy-bump.yaml
+++ b/changelog/v1.26.8-patch1/envoy-bump.yaml
@@ -3,6 +3,7 @@ changelog:
     dependencyRepo: envoy
     dependencyOwner: envoyproxy
     dependencyTag: v1.26.8
+    issueLink: https://github.com/solo-io/solo-projects/issues/6008
     description: >
       Bump Envoy to v1.26.8 for our fork.
       Tackles the http2 crazy cve CVE-2024-30255


### PR DESCRIPTION
Bumps the repo only. 
Envoy-fork was fastforwarded
BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/6008