### PR TITLE
1.27 | bazel: Update to a newer version of envoy-fork with http2 continuation cve

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
         # envoy 1.27.4 from release v1.27.4-fork2
-        commit = " 31f980b46a9ee24c545655be82b6849d6b9a16a8",
+        commit = "31f980b46a9ee24c545655be82b6849d6b9a16a8",
         remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
-        # envoy 1.27.3 from release v1.27.3-fork1
-        commit = "ebfb8ff1944e55756318f89bea189e0470daaed0",
+        # envoy 1.27.4 from release v1.27.4-fork2
+        commit = " 31f980b46a9ee24c545655be82b6849d6b9a16a8",
         remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(

--- a/changelog/v1.27.4-patch1/cve-bump-envoy.yaml
+++ b/changelog/v1.27.4-patch1/cve-bump-envoy.yaml
@@ -1,0 +1,10 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-fork
+  dependencyTag: v1.27.4-fork1
+  issueLink: https://github.com/solo-io/solo-projects/issues/6008
+  resolvesIssue: false
+  description: >
+    Bump to upstream envoy v1.27.4 
+    Tackles the http2 crazy cve CVE-2024-30255

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -53,13 +53,22 @@ steps:
   - 'TAGGED_VERSION=$TAG_NAME'
 
 options:
-  machineType: 'N1_HIGHCPU_32'
+  pool:
+    name: 'projects/solo-public/locations/us-central1/workerPools/envoy-gloo-runner'
 timeout: 20000s
 
 artifacts:
   objects:
     location: 'gs://solo-public-artifacts.solo.io/envoy/$COMMIT_SHA/'
     paths: ['linux/amd64/build_envoy_release/envoy']
+
+tags:
+  - "repo_envoy-gloo"
+  # This tag can be used to filter for or out jobs which are spawned by the main job
+  # submitted by build-bot. It's somewhat redundant as one could filter on `tags~^pr`
+  # to achieve the same effect since that tag is added to main jobs by build-bot,
+  # but this is somewhat less esoteric
+  - "sub-job"
 
 availableSecrets:
   inline:

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -32,11 +32,14 @@ fi
 
 export ENVOY_SRCDIR=$SOURCE_DIR
 
+<<<<<<< HEAD
 # google cloud build times out when using full throttle.
 export NUM_CPUS=10
 
+=======
+>>>>>>> a7e11ff (Use private pool cloud build worker (#316))
 # google cloud build doesn't like ipv6
-export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors --jobs=${NUM_CPUS}"
+export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors"
 
 # We do not need/want to build the Envoy contrib filters so we replace the
 # associated targets with the ENVOY_BUILD values

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -46,6 +46,12 @@ export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test
 export ENVOY_CONTRIB_BUILD_TARGET="//source/exe:envoy-static"
 export ENVOY_CONTRIB_BUILD_DEBUG_INFORMATION="//source/exe:envoy-static.dwp"
 
+BAZEL_BUILD_EXTRA_OPTIONS+=" --remote_cache=${BAZEL_REMOTE_CACHE}"
+
+export  GCP_SERVICE_ACCOUNT_KEY_PATH=$(mktemp -t gcp_service_account.XXXXXX.json)
+echo "${GCP_SERVICE_ACCOUNT_KEY}" | base64 --decode > "${GCP_SERVICE_ACCOUNT_KEY_PATH}"
+BAZEL_BUILD_EXTRA_OPTIONS+=" --google_credentials=${GCP_SERVICE_ACCOUNT_KEY_PATH}"
+
 if [ "${BUILD_TYPE:-}" != "" ] ; then
   BUILD_CONFIG="--config=$BUILD_TYPE"
 fi

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -32,12 +32,6 @@ fi
 
 export ENVOY_SRCDIR=$SOURCE_DIR
 
-<<<<<<< HEAD
-# google cloud build times out when using full throttle.
-export NUM_CPUS=10
-
-=======
->>>>>>> a7e11ff (Use private pool cloud build worker (#316))
 # google cloud build doesn't like ipv6
 export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors"
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,12 @@
 steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['builds','submit','--config=ci/cloudbuild.yaml','--substitutions','TAG_NAME=$TAG_NAME,COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=']
+  id: "standard"
+  args: ['builds','submit','--region=us-central1','--config=ci/cloudbuild.yaml','--substitutions','TAG_NAME=$TAG_NAME,COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=']
 
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['builds','submit','--config=ci/cloudbuild.yaml','--substitutions','COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=clang-asan']
+  id: "asan"
+  args: ['builds','submit','--region=us-central1','--config=ci/cloudbuild.yaml','--substitutions','COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=clang-asan']
   waitFor: ['-']
 
 timeout: 20000s


### PR DESCRIPTION
Bumps the repo only.
Envoy-fork was fastforwarded