### PR TITLE
1.28 | bazel: update to a newer version of envoy-fork with http2 continuation cve

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
-        # envoy 1.28.1 with backported ext_proc updates
-        commit = "47d4c36d399b9daae47cd7f6c4d41cf75e7e3ff8",
+        # envoy 1.28.2 with backported ext_proc updates
+        commit = "3a260838159e2d4ba6d2499e1d6bd6740e55fce5",
         remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(

--- a/changelog/v1.28.2-patch1/bump-envoy.yaml
+++ b/changelog/v1.28.2-patch1/bump-envoy.yaml
@@ -1,0 +1,10 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-fork
+  dependencyTag: v1.28.2
+  resolvesIssue: false
+  issueLink: https://github.com/solo-io/solo-projects/issues/6008
+  description: >-
+    Update Envoy to latest from forked 1.28.2
+    Tackles the http2 crazy cve CVE-2024-30255

--- a/ci/cloudbuild.yaml
+++ b/ci/cloudbuild.yaml
@@ -53,13 +53,22 @@ steps:
   - 'TAGGED_VERSION=$TAG_NAME'
 
 options:
-  machineType: 'N1_HIGHCPU_32'
+  pool:
+    name: 'projects/solo-public/locations/us-central1/workerPools/envoy-gloo-runner'
 timeout: 20000s
 
 artifacts:
   objects:
     location: 'gs://solo-public-artifacts.solo.io/envoy/$COMMIT_SHA/'
     paths: ['linux/amd64/build_envoy_release/envoy']
+
+tags:
+  - "repo_envoy-gloo"
+  # This tag can be used to filter for or out jobs which are spawned by the main job
+  # submitted by build-bot. It's somewhat redundant as one could filter on `tags~^pr`
+  # to achieve the same effect since that tag is added to main jobs by build-bot,
+  # but this is somewhat less esoteric
+  - "sub-job"
 
 availableSecrets:
   inline:

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -31,11 +31,8 @@ fi
 
 export ENVOY_SRCDIR=$SOURCE_DIR
 
-# google cloud build times out when using full throttle.
-export NUM_CPUS=10
-
 # google cloud build doesn't like ipv6
-export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors --jobs=${NUM_CPUS}"
+export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors"
 
 # We do not need/want to build the Envoy contrib filters so we replace the
 # associated targets with the ENVOY_BUILD values

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,12 @@
 steps:
 
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['builds','submit','--config=ci/cloudbuild.yaml','--substitutions','TAG_NAME=$TAG_NAME,COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=']
+  id: "standard"
+  args: ['builds','submit','--region=us-central1','--config=ci/cloudbuild.yaml','--substitutions','TAG_NAME=$TAG_NAME,COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=']
 
 - name: 'gcr.io/cloud-builders/gcloud'
-  args: ['builds','submit','--config=ci/cloudbuild.yaml','--substitutions','COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=clang-asan']
+  id: "asan"
+  args: ['builds','submit','--region=us-central1','--config=ci/cloudbuild.yaml','--substitutions','COMMIT_SHA=$COMMIT_SHA,_BUILD_TYPE=clang-asan']
   waitFor: ['-']
 
 timeout: 20000s


### PR DESCRIPTION
Bumps the repo only.
Envoy-fork was fastforwarded
