### PR TITLE
Add base64url fallback to base64_decode

### DIFF
--- a/changelog/v1.29.3-patch2/base64url.yaml
+++ b/changelog/v1.29.3-patch2/base64url.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/envoy-gloo/issues/329
+  resolvesIssue: false
+  description: >-
+    Fall back to attempting to decode Base64Url if Base64 decoding fails in the Inja transformation
+    base64_decode callback. This can happen especially when attempting to decode JWTs.

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -10,6 +10,7 @@
 #include "source/common/regex/regex.h"
 #include "source/common/common/utility.h"
 #include "source/common/config/metadata.h"
+#include "source/common/common/empty_string.h"
 
 #include "source/extensions/filters/http/solo_well_known_names.h"
 
@@ -390,7 +391,22 @@ json TransformerInstance::base64_encode_callback(const inja::Arguments &args) co
 
 json TransformerInstance::base64_decode_callback(const inja::Arguments &args) const {
   const std::string &input = args.at(0)->get_ref<const std::string &>();
-  return Base64::decode(input);
+
+  std::cout << input << std::endl;
+
+  // First try decoding standard base64
+  auto b64 = Base64::decode(input);
+  std::cout << "b64 after standard decode: " << b64 << std::endl;
+
+  std::cout << (b64 == EMPTY_STRING) << std::endl;
+
+  // If this failed it might be because of base64url encoding
+  if (b64 == EMPTY_STRING) {
+    b64 = Base64Url::decode(input);
+  std::cout << "b64 after url decode: " << b64 << std::endl;
+  }
+
+  return b64;
 }
 
 // return a substring of the input string, starting at the start position

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -400,12 +400,6 @@ json TransformerInstance::base64url_encode_callback(const inja::Arguments &args)
   return Base64Url::encode(input.c_str(), input.length());
 }
 
-json TransformerInstance::base64url_decode_callback(const inja::Arguments &args) const {
-  const std::string &input = args.at(0)->get_ref<const std::string &>();
-
-  return Base64Url::decode(input);
-}
-
 json TransformerInstance::base64_decode_callback(const inja::Arguments &args) const {
   const std::string &input = args.at(0)->get_ref<const std::string &>();
 
@@ -416,6 +410,21 @@ json TransformerInstance::base64_decode_callback(const inja::Arguments &args) co
   // https://datatracker.ietf.org/doc/html/rfc4648#section-5
   if (b64 == EMPTY_STRING) {
     b64 = Base64Url::decode(input);
+  }
+
+  return b64;
+}
+
+json TransformerInstance::base64url_decode_callback(const inja::Arguments &args) const {
+  const std::string &input = args.at(0)->get_ref<const std::string &>();
+
+  // First try decoding base64url
+  // https://datatracker.ietf.org/doc/html/rfc4648#section-5
+  auto b64 = Base64Url::decode(input);
+
+  // If this failed it might be because of standard base64 encoding
+  if (b64 == EMPTY_STRING) {
+    b64 = Base64::decode(input);
   }
 
   return b64;

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -396,9 +396,9 @@ json TransformerInstance::base64_decode_callback(const inja::Arguments &args) co
   auto b64 = Base64::decode(input);
 
   // If this failed it might be because of base64url encoding
-  if (b64 == EMPTY_STRING) {
-    b64 = Base64Url::decode(input);
-  }
+  /* if (b64 == EMPTY_STRING) { */
+  /*   b64 = Base64Url::decode(input); */
+  /* } */
 
   return b64;
 }

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -402,32 +402,12 @@ json TransformerInstance::base64url_encode_callback(const inja::Arguments &args)
 
 json TransformerInstance::base64_decode_callback(const inja::Arguments &args) const {
   const std::string &input = args.at(0)->get_ref<const std::string &>();
-
-  // First try decoding standard base64
-  auto b64 = Base64::decode(input);
-
-  // If this failed it might be because of base64url encoding
-  // https://datatracker.ietf.org/doc/html/rfc4648#section-5
-  if (b64 == EMPTY_STRING) {
-    b64 = Base64Url::decode(input);
-  }
-
-  return b64;
+  return Base64::decode(input);
 }
 
 json TransformerInstance::base64url_decode_callback(const inja::Arguments &args) const {
   const std::string &input = args.at(0)->get_ref<const std::string &>();
-
-  // First try decoding base64url
-  // https://datatracker.ietf.org/doc/html/rfc4648#section-5
-  auto b64 = Base64Url::decode(input);
-
-  // If this failed it might be because of standard base64 encoding
-  if (b64 == EMPTY_STRING) {
-    b64 = Base64::decode(input);
-  }
-
-  return b64;
+  return Base64Url::decode(input);
 }
 
 // return a substring of the input string, starting at the start position

--- a/source/extensions/filters/http/transformation/inja_transformer.cc
+++ b/source/extensions/filters/http/transformation/inja_transformer.cc
@@ -392,18 +392,12 @@ json TransformerInstance::base64_encode_callback(const inja::Arguments &args) co
 json TransformerInstance::base64_decode_callback(const inja::Arguments &args) const {
   const std::string &input = args.at(0)->get_ref<const std::string &>();
 
-  std::cout << input << std::endl;
-
   // First try decoding standard base64
   auto b64 = Base64::decode(input);
-  std::cout << "b64 after standard decode: " << b64 << std::endl;
-
-  std::cout << (b64 == EMPTY_STRING) << std::endl;
 
   // If this failed it might be because of base64url encoding
   if (b64 == EMPTY_STRING) {
     b64 = Base64Url::decode(input);
-  std::cout << "b64 after url decode: " << b64 << std::endl;
   }
 
   return b64;

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -66,7 +66,9 @@ private:
   nlohmann::json env(const inja::Arguments &args) const;
   nlohmann::json cluster_metadata_callback(const inja::Arguments &args) const;
   nlohmann::json base64_encode_callback(const inja::Arguments &args) const;
+  nlohmann::json base64url_encode_callback(const inja::Arguments &args) const;
   nlohmann::json base64_decode_callback(const inja::Arguments &args) const;
+  nlohmann::json base64url_decode_callback(const inja::Arguments &args) const;
   nlohmann::json substring_callback(const inja::Arguments &args) const;
   nlohmann::json replace_with_random_callback(const inja::Arguments &args);
   std::string& random_for_pattern(const std::string& pattern);

--- a/test/extensions/filters/http/transformation/inja_transformer_test.cc
+++ b/test/extensions/filters/http/transformation/inja_transformer_test.cc
@@ -891,7 +891,7 @@ TEST_F(InjaTransformerTest, Base64UrlDecodeJWT) {
   // JWT with an underscore which is an invalid base64 character
   auto encoded_string = "eyJzdWIiOiJhYW_DsCJ9";
 
-  auto formatted_string = fmt::format("{{{{base64_decode(\"{}\")}}}}", encoded_string);
+  auto formatted_string = fmt::format("{{{{base64url_decode(\"{}\")}}}}", encoded_string);
 
   transformation.mutable_body()->set_text(formatted_string);
 


### PR DESCRIPTION
JWTs and other usages use a modified character set from the standard base64. This variant is called base64url. When our Transformation filter is presented with a base64url encoded string to the base64_decode inja callback, the transformation fails silently because the decode returned an empty string.

This PR introduces a new pair of callbacks capable of handling `base64url` encoding
