### PR TITLE
bazel: bump envoy 1.30.2  for upstream cves

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -2,8 +2,8 @@ REPOSITORY_LOCATIONS = dict(
     # can't have more than one comment between envoy line and commit line in 
     # order to accommodate `check_extensions_build_config.sh`
     envoy = dict(
-        # envoy v1.30.1
-        commit = "816188b86a0a52095b116b107f576324082c7c02",
+        # envoy v1.30.2
+        commit = "d79f6e8d453ee260e9094093b8dd31af0056e67b",
         remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(

--- a/changelog/v1.30.2-patch1/bump-envoy.yaml
+++ b/changelog/v1.30.2-patch1/bump-envoy.yaml
@@ -1,0 +1,16 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  issueLink: https://github.com/solo-io/solo-projects/issues/6290
+  dependencyOwner: envoyproxy
+  dependencyRepo: envoy
+  dependencyTag: v1.30.2-patch1
+  resolvesIssue: false
+  description: >-
+    Update Envoy to latest 1.30.2-patch1 release for cves.
+    - [CVE-2024-34362: Crash (use-after-free) in EnvoyQuicServerStream](GHSA-hww5-43gv-35jv)
+    - [CVE-2024-34363: Crash due to uncaught nlohmann JSON exception](GHSA-g979-ph9j-5gg4)
+    - [CVE-2024-34364: Envoy OOM vector from HTTP async client with unbounded response buffer for mirror response, and other components](GHSA-xcj3-h7vf-fw26)
+    - [CVE-2024-32974: Crash in EnvoyQuicServerStream::OnInitialHeadersComplete()](GHSA-mgxp-7hhp-8299)
+    - [CVE-2024-32975: Crash in QuicheDataReader::PeekVarInt62Length()](GHSA-g9mq-6v96-cpqc)
+    - [CVE-2024-32976: Endless loop while decompressing Brotli data with extra input](GHSA-7wp5-c2vq-4f8m)
+    - [CVE-2024-23326: Envoy incorrectly accepts HTTP 200 response for entering upgrade mode](GHSA-vcf8-7238-v74c)


### PR DESCRIPTION
    Update Envoy to latest 1.30.2-patch1 release for cves.
    - [CVE-2024-34362: Crash (use-after-free) in EnvoyQuicServerStream](GHSA-hww5-43gv-35jv)
    - [CVE-2024-34363: Crash due to uncaught nlohmann JSON exception](GHSA-g979-ph9j-5gg4)
    - [CVE-2024-34364: Envoy OOM vector from HTTP async client with unbounded response buffer for mirror response, and other components](GHSA-xcj3-h7vf-fw26)
    - [CVE-2024-32974: Crash in EnvoyQuicServerStream::OnInitialHeadersComplete()](GHSA-mgxp-7hhp-8299)
    - [CVE-2024-32975: Crash in QuicheDataReader::PeekVarInt62Length()](GHSA-g9mq-6v96-cpqc)
    - [CVE-2024-32976: Endless loop while decompressing Brotli data with extra input](GHSA-7wp5-c2vq-4f8m)
    - [CVE-2024-23326: Envoy incorrectly accepts HTTP 200 response for entering upgrade mode](GHSA-vcf8-7238-v74c)
