### PR TITLE
bazel: bump envoy for upstream cves

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,7 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
-        # envoy 1.27.5 from release v1.27.5-fork1
-        commit = "defe1b87c9aaa8c2881b4dcd20813c733932e768",
+        # envoy 1.27.6 from release v1.27.6-fork1
+        commit = "a7fbe6da6f653c4523a751cb8d9462e24cc28ca8",
         remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(

--- a/changelog/v1.27.6-patch1/cve-bump-envoy.yaml
+++ b/changelog/v1.27.6-patch1/cve-bump-envoy.yaml
@@ -1,0 +1,17 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-fork
+  dependencyTag: v1.27.6-fork1
+  issueLink: https://github.com/solo-io/solo-projects/issues/6290
+  resolvesIssue: false
+  description: >
+    Bump to upstream envoy v1.27.6
+    - [CVE-2024-34362: Crash (use-after-free) in EnvoyQuicServerStream](GHSA-hww5-43gv-35jv)
+    - [CVE-2024-34363: Crash due to uncaught nlohmann JSON exception](GHSA-g979-ph9j-5gg4)
+    - [CVE-2024-34364: Envoy OOM vector from HTTP async client with unbounded response buffer for mirror response, and other components](GHSA-xcj3-h7vf-fw26)
+    - [CVE-2024-32974: Crash in EnvoyQuicServerStream::OnInitialHeadersComplete()](GHSA-mgxp-7hhp-8299)
+    - [CVE-2024-32975: Crash in QuicheDataReader::PeekVarInt62Length()](GHSA-g9mq-6v96-cpqc)
+    - [CVE-2024-32976: Endless loop while decompressing Brotli data with extra input](GHSA-7wp5-c2vq-4f8m)
+    - [CVE-2024-23326: Envoy incorrectly accepts HTTP 200 response for entering upgrade mode](GHSA-vcf8-7238-v74c)
+    


### PR DESCRIPTION
    Update Envoy to latest 1.30.2-patch1 release for cves.
    - [CVE-2024-34362: Crash (use-after-free) in EnvoyQuicServerStream](GHSA-hww5-43gv-35jv)
    - [CVE-2024-34363: Crash due to uncaught nlohmann JSON exception](GHSA-g979-ph9j-5gg4)
    - [CVE-2024-34364: Envoy OOM vector from HTTP async client with unbounded response buffer for mirror response, and other components](GHSA-xcj3-h7vf-fw26)
    - [CVE-2024-32974: Crash in EnvoyQuicServerStream::OnInitialHeadersComplete()](GHSA-mgxp-7hhp-8299)
    - [CVE-2024-32975: Crash in QuicheDataReader::PeekVarInt62Length()](GHSA-g9mq-6v96-cpqc)
    - [CVE-2024-32976: Endless loop while decompressing Brotli data with extra input](GHSA-7wp5-c2vq-4f8m)
    - [CVE-2024-23326: Envoy incorrectly accepts HTTP 200 response for entering upgrade mode](GHSA-vcf8-7238-v74c)
