### PR TITLE
Add filter-state rate limit hits_addend modifier patch

### DIFF
--- a/bazel/foreign_cc/0002-ratelimit-filter-state-hits-addend.patch
+++ b/bazel/foreign_cc/0002-ratelimit-filter-state-hits-addend.patch
@@ -1,0 +1,73 @@
+diff --git source/extensions/filters/http/ratelimit/BUILD source/extensions/filters/http/ratelimit/BUILD
+index fd4c15c81a..4009c2004c 100644
+--- source/extensions/filters/http/ratelimit/BUILD
++++ source/extensions/filters/http/ratelimit/BUILD
+@@ -25,6 +25,8 @@ envoy_cc_library(
+         "//source/common/common:enum_to_int",
+         "//source/common/http:codes_lib",
+         "//source/common/router:config_lib",
++        "//source/common/stream_info:uint32_accessor_lib",
++        "//envoy/stream_info:uint32_accessor_interface",
+         "//source/extensions/filters/common/ratelimit:ratelimit_client_interface",
+         "//source/extensions/filters/common/ratelimit:stat_names_lib",
+         "@envoy_api//envoy/extensions/filters/http/ratelimit/v3:pkg_cc_proto",
+diff --git source/extensions/filters/http/ratelimit/ratelimit.cc source/extensions/filters/http/ratelimit/ratelimit.cc
+index 5a462979be..53de5ee2d7 100644
+--- source/extensions/filters/http/ratelimit/ratelimit.cc
++++ source/extensions/filters/http/ratelimit/ratelimit.cc
+@@ -11,6 +11,8 @@
+ #include "source/common/http/codes.h"
+ #include "source/common/http/header_utility.h"
+ #include "source/common/router/config_impl.h"
++#include "envoy/stream_info/stream_info.h"
++#include "source/common/stream_info/uint32_accessor_impl.h"
+ #include "source/extensions/filters/http/ratelimit/ratelimit_headers.h"
+ 
+ namespace Envoy {
+@@ -18,6 +20,23 @@ namespace Extensions {
+ namespace HttpFilters {
+ namespace RateLimitFilter {
+ 
++constexpr absl::string_view HitsAddendFilterStateKey = "envoy.ratelimit.hits_addend";
++
++class HitsAddendObjectFactory : public StreamInfo::FilterState::ObjectFactory {
++public:
++  std::string name() const override { return std::string(HitsAddendFilterStateKey); }
++  std::unique_ptr<StreamInfo::FilterState::Object>
++  createFromBytes(absl::string_view data) const override {
++    uint32_t port = 0;
++    if (absl::SimpleAtoi(data, &port)) {
++      return std::make_unique<StreamInfo::UInt32AccessorImpl>(port);
++    }
++    return nullptr;
++  }
++};
++
++REGISTER_FACTORY(HitsAddendObjectFactory, StreamInfo::FilterState::ObjectFactory);
++
+ struct RcDetailsValues {
+   // This request went above the configured limits for the rate limit filter.
+   const std::string RateLimited = "request_rate_limited";
+@@ -66,11 +85,21 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
+     break;
+   }
+ 
++  const StreamInfo::UInt32Accessor* hits_addend_filter_state =
++    callbacks_
++        ->streamInfo()
++        .filterState()
++        ->getDataReadOnly<StreamInfo::UInt32Accessor>("envoy.ratelimit.hits_addend");
++  double hits_addend = 0;
++  if (hits_addend_filter_state != nullptr) {
++    hits_addend = hits_addend_filter_state->value();
++  }
++
+   if (!descriptors.empty()) {
+     state_ = State::Calling;
+     initiating_call_ = true;
+     client_->limit(*this, getDomain(), descriptors, callbacks_->activeSpan(),
+-                   callbacks_->streamInfo(), 0);
++                   callbacks_->streamInfo(), hits_addend);
+     initiating_call_ = false;
+   }
+ }

--- a/bazel/foreign_cc/0002-ratelimit-filter-state-hits-addend.patch
+++ b/bazel/foreign_cc/0002-ratelimit-filter-state-hits-addend.patch
@@ -1,33 +1,46 @@
 diff --git source/extensions/filters/http/ratelimit/BUILD source/extensions/filters/http/ratelimit/BUILD
-index fd4c15c81a..4009c2004c 100644
+index fd4c15c81a..6d56028db5 100644
 --- source/extensions/filters/http/ratelimit/BUILD
 +++ source/extensions/filters/http/ratelimit/BUILD
-@@ -25,6 +25,8 @@ envoy_cc_library(
+@@ -20,11 +20,13 @@ envoy_cc_library(
+         ":ratelimit_headers_lib",
+         "//envoy/http:codes_interface",
+         "//envoy/ratelimit:ratelimit_interface",
++        "//envoy/stream_info:uint32_accessor_interface",
+         "//source/common/common:assert_lib",
+         "//source/common/common:empty_string",
          "//source/common/common:enum_to_int",
          "//source/common/http:codes_lib",
          "//source/common/router:config_lib",
 +        "//source/common/stream_info:uint32_accessor_lib",
-+        "//envoy/stream_info:uint32_accessor_interface",
          "//source/extensions/filters/common/ratelimit:ratelimit_client_interface",
          "//source/extensions/filters/common/ratelimit:stat_names_lib",
          "@envoy_api//envoy/extensions/filters/http/ratelimit/v3:pkg_cc_proto",
 diff --git source/extensions/filters/http/ratelimit/ratelimit.cc source/extensions/filters/http/ratelimit/ratelimit.cc
-index 5a462979be..53de5ee2d7 100644
+index 382029e5f3..ec108cd5cb 100644
 --- source/extensions/filters/http/ratelimit/ratelimit.cc
 +++ source/extensions/filters/http/ratelimit/ratelimit.cc
-@@ -11,6 +11,8 @@
+@@ -4,6 +4,7 @@
+ #include <vector>
+ 
+ #include "envoy/http/codes.h"
++#include "envoy/stream_info/stream_info.h"
+ 
+ #include "source/common/common/assert.h"
+ #include "source/common/common/enum_to_int.h"
+@@ -11,6 +12,7 @@
  #include "source/common/http/codes.h"
  #include "source/common/http/header_utility.h"
  #include "source/common/router/config_impl.h"
-+#include "envoy/stream_info/stream_info.h"
 +#include "source/common/stream_info/uint32_accessor_impl.h"
  #include "source/extensions/filters/http/ratelimit/ratelimit_headers.h"
  
  namespace Envoy {
-@@ -18,6 +20,23 @@ namespace Extensions {
+@@ -18,6 +20,26 @@ namespace Extensions {
  namespace HttpFilters {
  namespace RateLimitFilter {
  
++namespace {
 +constexpr absl::string_view HitsAddendFilterStateKey = "envoy.ratelimit.hits_addend";
 +
 +class HitsAddendObjectFactory : public StreamInfo::FilterState::ObjectFactory {
@@ -35,9 +48,9 @@ index 5a462979be..53de5ee2d7 100644
 +  std::string name() const override { return std::string(HitsAddendFilterStateKey); }
 +  std::unique_ptr<StreamInfo::FilterState::Object>
 +  createFromBytes(absl::string_view data) const override {
-+    uint32_t port = 0;
-+    if (absl::SimpleAtoi(data, &port)) {
-+      return std::make_unique<StreamInfo::UInt32AccessorImpl>(port);
++    uint32_t hits_addend = 0;
++    if (absl::SimpleAtoi(data, &hits_addend)) {
++      return std::make_unique<StreamInfo::UInt32AccessorImpl>(hits_addend);
 +    }
 +    return nullptr;
 +  }
@@ -45,18 +58,18 @@ index 5a462979be..53de5ee2d7 100644
 +
 +REGISTER_FACTORY(HitsAddendObjectFactory, StreamInfo::FilterState::ObjectFactory);
 +
++} // namespace
++
  struct RcDetailsValues {
    // This request went above the configured limits for the rate limit filter.
    const std::string RateLimited = "request_rate_limited";
-@@ -66,11 +85,21 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
+@@ -64,11 +86,19 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
      break;
    }
  
 +  const StreamInfo::UInt32Accessor* hits_addend_filter_state =
-+    callbacks_
-+        ->streamInfo()
-+        .filterState()
-+        ->getDataReadOnly<StreamInfo::UInt32Accessor>("envoy.ratelimit.hits_addend");
++      callbacks_->streamInfo().filterState()->getDataReadOnly<StreamInfo::UInt32Accessor>(
++          "envoy.ratelimit.hits_addend");
 +  double hits_addend = 0;
 +  if (hits_addend_filter_state != nullptr) {
 +    hits_addend = hits_addend_filter_state->value();

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -68,6 +68,7 @@ def _repository_impl(name, **kwargs):
 def envoy_gloo_dependencies():
     _repository_impl("envoy", patches=[
         "@envoy_gloo//bazel/foreign_cc:0001-otel-exporter-status-code-fix.patch",
+        "@envoy_gloo//bazel/foreign_cc:0002-ratelimit-filter-state-hits-addend.patch",
     ])
     _repository_impl("json", build_file = "@envoy_gloo//bazel/external:json.BUILD")
     _repository_impl("inja", build_file = "@envoy_gloo//bazel/external:inja.BUILD")

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -2,12 +2,9 @@ REPOSITORY_LOCATIONS = dict(
     # can't have more than one comment between envoy line and commit line in 
     # order to accommodate `check_extensions_build_config.sh`
     envoy = dict(
-        # envoy-fork release/v1.30-4-backported-filter-state-hits-addend
-        # This fork includes the following PR which has yet to be merged upstream:
-        # https://github.com/envoyproxy/envoy/pull/34184.
-        # Once this merges upstream we can bump the envoy version and get rid of the fork.
-        commit = "ed3a8b9ac0748d9b968e978945fdf930fad46bdf",
-        remote = "https://github.com/solo-io/envoy-fork",
+        # envoy v1.30.4
+        commit = "32113313a357829ba3a5dce0795b6780bf8cbf4d",
+        remote = "https://github.com/envoyproxy/envoy",
     ),
     inja = dict(
         # Includes unmerged modifications for

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -2,9 +2,12 @@ REPOSITORY_LOCATIONS = dict(
     # can't have more than one comment between envoy line and commit line in 
     # order to accommodate `check_extensions_build_config.sh`
     envoy = dict(
-        # envoy v1.30.4
-        commit = "32113313a357829ba3a5dce0795b6780bf8cbf4d",
-        remote = "https://github.com/envoyproxy/envoy",
+        # envoy-fork release/v1.30-4-backported-filter-state-hits-addend
+        # This fork includes the following PR which has yet to be merged upstream:
+        # https://github.com/envoyproxy/envoy/pull/34184.
+        # Once this merges upstream we can bump the envoy version and get rid of the fork.
+        commit = "ed3a8b9ac0748d9b968e978945fdf930fad46bdf",
+        remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(
         # Includes unmerged modifications for

--- a/changelog/v1.30.4-patch3/bump-envoy-fork.yaml
+++ b/changelog/v1.30.4-patch3/bump-envoy-fork.yaml
@@ -4,6 +4,4 @@ changelog:
   dependencyRepo: envoy-fork
   dependencyTag: ed3a8b9ac0748d9b968e978945fdf930fad46bdf
   description: >-
-    Update envoy fork to ed3a8b9ac0748d9b968e978945fdf930fad46bdf.
-    We need to rely on the fork temporarily until the following PR is merged upstream:
-    https://github.com/envoyproxy/envoy/pull/34184
+    Backport unmerged hits addended pr: https://github.com/envoyproxy/envoy/pull/34184

--- a/changelog/v1.30.4-patch3/bump-envoy-fork.yaml
+++ b/changelog/v1.30.4-patch3/bump-envoy-fork.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-fork
+  dependencyTag: ed3a8b9ac0748d9b968e978945fdf930fad46bdf
+  description: >-
+    Update envoy fork to ed3a8b9ac0748d9b968e978945fdf930fad46bdf.
+    We need to rely on the fork temporarily until the following PR is merged upstream:
+    https://github.com/envoyproxy/envoy/pull/34184


### PR DESCRIPTION
Unfortunately the envoy OSS PR to set `hits_addend` has not merged yet. https://github.com/envoyproxy/envoy/pull/34184.
In the meantime we can add a patch of the changes

To reproduce this patch file, check out the branch from the PR above, and then run the following command:
`git diff --no-prefix 1d5aa24a2f282cdb541f755131465e59eae8e624 source/`