### PR TITLE
1.27: Update to allow deallocating TLS on worker threads

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1,7 +1,8 @@
 REPOSITORY_LOCATIONS = dict(
     envoy = dict(
         # envoy 1.27.5 from release v1.27.5-fork1
-        commit = "defe1b87c9aaa8c2881b4dcd20813c733932e768",
+        # add backport of https://github.com/envoyproxy/envoy/pull/33395
+        commit = "98114a2ccdae0824613b7d304d6adb22ead5c9fb",
         remote = "https://github.com/solo-io/envoy-fork",
     ),
     inja = dict(

--- a/changelog/v1.27.7-patch2/deallocate-tls-on-worker-thread.yaml
+++ b/changelog/v1.27.7-patch2/deallocate-tls-on-worker-thread.yaml
@@ -4,3 +4,13 @@ changelog:
   resolvesIssue: false
   description: >
     Backport an upstream Envoy fix that allows deallocating thread-local slots on worker threads.
+- type: FIX
+  issueLink: https://github.com/solo-io/envoy-gloo/pull/292
+  resolvesIssue: false
+  description: >
+    Fix an issue in the ci/check_extensions_build_config.sh script. One of the
+    grep commands was simply grepping for 'commit', which meant that any other
+    line in the file that contained the same word would also show up in the
+    grep, thereby messing up any string processing that followed. We fix this
+    by making the grep a bit stricter, ie. ensuring that the line _starts_ with
+    'commit' (barring any preceding whitespace for indentation purposes).

--- a/changelog/v1.27.7-patch2/deallocate-tls-on-worker-thread.yaml
+++ b/changelog/v1.27.7-patch2/deallocate-tls-on-worker-thread.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/6713
+  resolvesIssue: false
+  description: >
+    Backport an upstream Envoy fix that allows deallocating thread-local slots on worker threads.

--- a/ci/check_extensions_build_config.sh
+++ b/ci/check_extensions_build_config.sh
@@ -24,7 +24,7 @@ get_UPSTREAM_REPO() {
 get_envoy_commit_hash() {
     local file_path="$1"
     local commit_hash
-    commit_hash=$(grep -A 2 "envoy =" "$file_path" | grep commit | cut -d '"' -f 2)
+    commit_hash=$(grep -A 2 "envoy =" "$file_path" | grep '^ *commit' | cut -d '"' -f 2)
     echo "$commit_hash"
 }
 


### PR DESCRIPTION
Fixes one of our ci elements and backports the upstream thread local storage fix.

The thread local storage destructor changes can be reverted via envoy_restart_features_allow_slot_destroy_on_worker_threads