### PR TITLE
metadata-subpaths

### DIFF
--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -314,6 +314,12 @@ message TransformationTemplate {
   // rendered string values to be escaped in order to make valid JSON/YAML strings
   bool escape_characters = 12;
 
+  // The character to use as a delimiter when accessing dynamic metadata values
+  // in templates. Defaults to ':' if unset.
+  // See https://www.envoyproxy.io/docs/envoy/v1.31.1/configuration/observability/access_log/usage.html
+  // for more information.
+  string string_delimiter = 14;
+
 }
 
 // Defines an [Inja template](https://github.com/pantor/inja) that will be

--- a/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
+++ b/api/envoy/config/filter/http/transformation/v2/transformation_filter.proto
@@ -316,7 +316,7 @@ message TransformationTemplate {
 
   // The character to use as a delimiter when accessing dynamic metadata values
   // in templates. Defaults to ':' if unset.
-  // See https://www.envoyproxy.io/docs/envoy/v1.31.1/configuration/observability/access_log/usage.html
+  // See https://www.envoyproxy.io/docs/envoy/v1.31.1/configuration/observability/access_log/usage.html#config-access-log-format-dynamic-metadata
   // for more information.
   string string_delimiter = 14;
 

--- a/changelog/v1.31.0-patch2/transformer-metadata-subpaths.yaml
+++ b/changelog/v1.31.0-patch2/transformer-metadata-subpaths.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: FIX
+  resolvesIssue: false
+  description: >-
+    Allow usage of subpaths in Metadata funcs within inja templates.
+  issueLink: https://github.com/solo-io/solo-projects/issues/6875
+

--- a/source/extensions/filters/http/transformation/inja_transformer.h
+++ b/source/extensions/filters/http/transformation/inja_transformer.h
@@ -41,6 +41,7 @@ public:
   const envoy::config::core::v3::Metadata *cluster_metadata_;
   Envoy::Upstream::MetadataConstSharedPtr endpoint_metadata_;
   const envoy::config::core::v3::Metadata *dynamic_metadata_;
+  char metadata_string_delimiter_ = ':';
 };
 
 
@@ -79,6 +80,7 @@ private:
   std::string& random_for_pattern(const std::string& pattern);
   nlohmann::json raw_string_callback(const inja::Arguments &args) const;
   static nlohmann::json parse_metadata(const envoy::config::core::v3::Metadata* metadata,
+                                                  char delimiter,
                                                   const inja::Arguments &args);
   static nlohmann::json word_count_callback(const inja::Arguments &args);
   static int json_word_count(const nlohmann::json* str);
@@ -161,6 +163,7 @@ private:
   std::vector<std::tuple<std::string, bool, inja::Template>> merge_templates_;
   ThreadLocal::SlotPtr tls_;
   std::unique_ptr<TransformerInstance> instance_;
+  char metadata_string_delimiter_ = ':';
 };
 
 } // namespace Transformation


### PR DESCRIPTION
Allow usage of subpaths in Metadata funcs within `inja` templates.

The `TransformationTemplate` API now has a `string_delimiter` field to enable swapping the delimiter if necessary given the contents of the metadata keys. By default it is set to `:`.