### PR TITLE
[1.30]: Enabling EHM extension

### DIFF
--- a/bazel/extensions/extensions_build_config.bzl
+++ b/bazel/extensions/extensions_build_config.bzl
@@ -487,7 +487,7 @@ EXTENSIONS = {
     #
     # HTTP Early Header Mutation
     #
-    # "envoy.http.early_header_mutation.header_mutation": "//source/extensions/http/early_header_mutation/header_mutation:config",
+    "envoy.http.early_header_mutation.header_mutation": "//source/extensions/http/early_header_mutation/header_mutation:config",
 
 
     #

--- a/changelog/v1.30.6-patch5/enable-ehm-extension.yaml
+++ b/changelog/v1.30.6-patch5/enable-ehm-extension.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/9604
+    resolvesIssue: false
+    description: >-
+      Enable early header mutation extension.


### PR DESCRIPTION
Backporting enabling the Early Header Mutation extension.

Re: https://github.com/solo-io/gloo/pull/10295/files/76dec938716b4093ec4a003c6a5fe0149cb8a695#r1833497993