### PR TITLE
[1.31] ci: bump EOL github upload action

### DIFF
--- a/.github/workflows/check-extensions-build-config.yaml
+++ b/.github/workflows/check-extensions-build-config.yaml
@@ -11,14 +11,14 @@ jobs:
     name: check-extensions-build-config
     runs-on: ubuntu-20.04-8core
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Add safe directory
       run: git config --global --add safe.directory /__w/envoy-gloo-ee/envoy-gloo-ee
     - name: Run check-extensions-build-config.sh
       run: ci/check_extensions_build_config.sh
     # - name: Archive check results
       # if: ${{ !cancelled() }}
-      # uses: actions/upload-artifact@v3
+      # uses: actions/upload-artifact@v4
       # with:
       #   name: static-analysis-report
       #   path: linux/amd64/analysis/scan-build-*/

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -19,7 +19,7 @@ jobs:
       run: ci/static_analysis.sh
     - name: Archive static analysis results
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: static-analysis-report
         path: linux/amd64/analysis/scan-build-*/

--- a/changelog/v1.31.2-patch4/bump-upload-artifact.yaml
+++ b/changelog/v1.31.2-patch4/bump-upload-artifact.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Bump EOL'd github upload action
+    


### PR DESCRIPTION
Bump EOL'd github upload/download action to v4

This is used in the 1.19 && 1.18 version of Edge