### PR TITLE
[1.29] bazel: bump 12912

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -2,9 +2,9 @@ REPOSITORY_LOCATIONS = dict(
     # can't have more than one comment between envoy line and commit line in 
     # order to accommodate `check_extensions_build_config.sh`
     envoy = dict(
-        # envoy 1.29.3 with backported ext_proc updates
-        commit = "e2dab93e60e93b56fa63632fb9cfa64930fc5240", # v1.29.3-fork1
-        remote = "https://github.com/solo-io/envoy-fork",
+        # envoy v1.29.12
+        commit = "5c3dc559371181d5baa4a7533c36f2370fc97581",
+        remote = "https://github.com/envoyproxy/envoy", 
     ),
     inja = dict(
         # Includes unmerged modifications for

--- a/changelog/v1.29.12-patch1/bump-envoy.yaml
+++ b/changelog/v1.29.12-patch1/bump-envoy.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    issueLink: https://github.com/solo-io/envoy-gloo-ee/issues/868
+    dependencyOwner: envoyproxy
+    dependencyRepo: envoy
+    dependencyTag: 5c3dc559371181d5baa4a7533c36f2370fc97581
+    resolvesIssue: false
+    description: >-
+      CVE-2024-53270: HTTP/1: sending overload crashes when the request is reset beforehand

--- a/changelog/v1.29.12-patch1/bump-envoy.yaml
+++ b/changelog/v1.29.12-patch1/bump-envoy.yaml
@@ -3,7 +3,7 @@ changelog:
     issueLink: https://github.com/solo-io/envoy-gloo-ee/issues/868
     dependencyOwner: envoyproxy
     dependencyRepo: envoy
-    dependencyTag: 5c3dc559371181d5baa4a7533c36f2370fc97581
+    dependencyTag: v1.29.12
     resolvesIssue: false
     description: >-
       CVE-2024-53270: HTTP/1: sending overload crashes when the request is reset beforehand


### PR DESCRIPTION
CVE-2024-53270: HTTP/1: sending overload crashes when the request is reset beforehand

This branch is only used for istio builds