### PR TITLE
Fix AWS 429 response

### DIFF
--- a/changelog/v1.33.0-patch2/aws-lambda-429.yaml
+++ b/changelog/v1.33.0-patch2/aws-lambda-429.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/envoy-gloo/pull/407
+    resolvesIssue: true
+    description: >-
+      Provide better diagnostics in the AWS Lambda filter when the lambda
+      function is rate-limited. Status code will be set to 500 and the
+      `x-envoy-lambda-statuscode` header will be set to 429.

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.cc
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.cc
@@ -71,6 +71,39 @@ void ApiGatewayTransformer::transform(
       }
 }
 
+void ApiGatewayTransformer::handle429(
+    Http::ResponseHeaderMap *response_headers,
+    nlohmann::json &json_body,
+    Http::StreamFilterCallbacks &stream_filter_callbacks) const {
+  // if the lambda function is rate-limited, set the status to 500 and add a
+  // header that says aws rate-limited the request. note that this means the
+  // lambda function itself was rate-limited, not that it was accepted and
+  // `statusCode` was 429.
+  // https://github.com/kgateway-dev/kgateway/issues/10192
+  ENVOY_STREAM_LOG(debug, "lambda function was rate-limited; setting response code to 500", stream_filter_callbacks);
+  response_headers->setStatus(500);
+  response_headers->addCopy(LAMBDA_STATUS_CODE_HEADER, "429");
+
+  // the remainder of this function parses the body of the lambda function's
+  // response to populate the client response. in the case of a 429, aws
+  // responds with the following message body:
+  // {
+  //     "Reason": "ReservedFunctionConcurrentInvocationLimitExceeded",
+  //     "Type": "User",
+  //     "message": "Rate Exceeded."
+  // }
+  // add Reason as a header so users know why it was throttled. see
+  // https://docs.aws.amazon.com/lambda/latest/api/API_Invoke.html
+  if (json_body.contains("Reason")) {
+    const auto& reason = json_body["Reason"];
+    std::string reason_string;
+    if (reason.is_string()) {
+      reason_string = reason.get<std::string>();
+      response_headers->addCopy(LAMBDA_STATUS_REASON_HEADER, reason_string);
+    }
+  }
+}
+
 void ApiGatewayTransformer::transform_response(
     Http::ResponseHeaderMap *response_headers,
     Buffer::Instance &body,
@@ -95,24 +128,7 @@ void ApiGatewayTransformer::transform_response(
 
   // set response status code
   if (received429) {
-    // if the lambda function is rate-limited, set the status to 500 and add a
-    // header that says aws rate-limited the request. note that this means the
-    // lambda function itself was rate-limited, not that it was accepted and
-    // `statusCode` was 429.
-    // https://github.com/kgateway-dev/kgateway/issues/10192
-    ENVOY_STREAM_LOG(debug, "lambda function was rate-limited; setting response code to 500", stream_filter_callbacks);
-    response_headers->setStatus(500);
-    response_headers->addCopy(LAMBDA_STATUS_CODE_HEADER, "429");
-    // the remainder of this function parses the body of the lambda function's
-    // response to populate the client response. in the case of a 429, aws
-    // responds with the following message body:
-    // {
-    //     "Reason": "ReservedFunctionConcurrentInvocationLimitExceeded",
-    //     "Type": "User",
-    //     "message": "Rate Exceeded."
-    // }
-    // parsing this message is a waste of CPU and since we have no use for it,
-    // so let's just return
+    handle429(response_headers, json_body, stream_filter_callbacks);
     return;
   }
   else if (json_body.contains("statusCode")) {

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
@@ -41,6 +41,7 @@ public:
   std::string name() const override { return "io.solo.api_gateway.api_gateway_transformer"; }
 };
 
+const Http::LowerCaseString LAMBDA_STATUS_CODE_HEADER("x-envoy-lambda-statuscode");
 
 class ApiGatewayTransformer : public Transformation::Transformer, Logger::Loggable<Logger::Id::filter> {
 public:

--- a/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
+++ b/source/extensions/transformers/aws_lambda/api_gateway_transformer.h
@@ -41,7 +41,8 @@ public:
   std::string name() const override { return "io.solo.api_gateway.api_gateway_transformer"; }
 };
 
-const Http::LowerCaseString LAMBDA_STATUS_CODE_HEADER("x-envoy-lambda-statuscode");
+const Http::LowerCaseString LAMBDA_STATUS_CODE_HEADER("x-envoygloo-lambda-statuscode");
+const Http::LowerCaseString LAMBDA_STATUS_REASON_HEADER("x-envoygloo-lambda-statusreason");
 
 class ApiGatewayTransformer : public Transformation::Transformer, Logger::Loggable<Logger::Id::filter> {
 public:
@@ -59,6 +60,10 @@ public:
                  Http::StreamFilterCallbacks &) const;
   bool passthrough_body() const override { return false; };
 private:
+  void handle429(
+      Http::ResponseHeaderMap *response_headers,
+      nlohmann::json &json_body,
+      Http::StreamFilterCallbacks &stream_filter_callbacks) const;
   static const Envoy::Http::LowerCaseString AMAZON_ERRORTYPE_HEADER;
   static constexpr uint64_t DEFAULT_STATUS_VALUE = 200;
   static void add_response_header(Http::ResponseHeaderMap &response_headers,

--- a/test/extensions/transformers/aws_lambda/transformer_test.cc
+++ b/test/extensions/transformers/aws_lambda/transformer_test.cc
@@ -50,6 +50,18 @@ TEST(ApiGatewayTransformer, transform) {
   EXPECT_EQ("application/json", response_headers.getContentTypeValue());
 }
 
+TEST(ApiGatewayTransformer, transform_response_ratelimited_lambda) {
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "429"}};
+  Buffer::OwnedImpl body("{}");
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks_{};
+
+  ApiGatewayTransformer transformer;
+  transformer.transform_response(&response_headers, body, filter_callbacks_);
+
+  EXPECT_EQ("500", response_headers.getStatusValue());
+  EXPECT_EQ("429", response_headers.get_(LAMBDA_STATUS_CODE_HEADER));
+}
+
 TEST(ApiGatewayTransformer, transform_body) {
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                          {":authority", "www.solo.io"},

--- a/test/extensions/transformers/aws_lambda/transformer_test.cc
+++ b/test/extensions/transformers/aws_lambda/transformer_test.cc
@@ -52,7 +52,11 @@ TEST(ApiGatewayTransformer, transform) {
 
 TEST(ApiGatewayTransformer, transform_response_ratelimited_lambda) {
   Http::TestResponseHeaderMapImpl response_headers{{":status", "429"}};
-  Buffer::OwnedImpl body("{}");
+  Buffer::OwnedImpl body(R"json({
+    "Reason": "TestReason",
+    "Type": "User",
+    "message": "Some message"
+  })json");
   NiceMock<Http::MockStreamDecoderFilterCallbacks> filter_callbacks_{};
 
   ApiGatewayTransformer transformer;
@@ -60,6 +64,7 @@ TEST(ApiGatewayTransformer, transform_response_ratelimited_lambda) {
 
   EXPECT_EQ("500", response_headers.getStatusValue());
   EXPECT_EQ("429", response_headers.get_(LAMBDA_STATUS_CODE_HEADER));
+  EXPECT_EQ("TestReason", response_headers.get_(LAMBDA_STATUS_REASON_HEADER));
 }
 
 TEST(ApiGatewayTransformer, transform_body) {


### PR DESCRIPTION
When AWS Lambda responds with a 429, set the status code to 500 and set the `x-envoy-lambda-statuscode` header to 429 to indicate that was the header received from AWS.

Reference: https://github.com/kgateway-dev/kgateway/issues/10192
BOT NOTES: 
resolves https://github.com/solo-io/envoy-gloo/pull/407