### PR TITLE
patch to fix upsteram issue for upstream filter disabled

### DIFF
--- a/bazel/foreign_cc/004-fixed-upstream-filter-disabled-by-default.patch
+++ b/bazel/foreign_cc/004-fixed-upstream-filter-disabled-by-default.patch
@@ -1,0 +1,783 @@
+From c4506595519559e29a5799fa9e55bda2ea594931 Mon Sep 17 00:00:00 2001
+From: Andy Fong <andy.fong@solo.io>
+Date: Fri, 13 Jun 2025 11:07:23 -0400
+Subject: [PATCH] fixed-upstream-filter-disabled-by-default
+
+Signed-off-by: Andy Fong <andy.fong@solo.io>
+---
+ source/common/http/filter_manager.cc          |   4 +-
+ source/common/http/utility.h                  |   4 +-
+ source/common/upstream/upstream_impl.h        |   6 +-
+ .../header_mutation_integration_test.cc       | 527 ++++++++++++++++--
+ .../upstream_http_filter_integration_test.cc  |  25 +-
+ 5 files changed, 514 insertions(+), 52 deletions(-)
+
+diff --git source/common/http/filter_manager.cc source/common/http/filter_manager.cc
+index 665c0572a9..56198d64ee 100644
+--- source/common/http/filter_manager.cc
++++ source/common/http/filter_manager.cc
+@@ -1679,9 +1679,7 @@ FilterManager::createFilterChain(const FilterChainFactory& filter_chain_factory)
+   OptRef<DownstreamStreamFilterCallbacks> downstream_callbacks =
+       filter_manager_callbacks_.downstreamCallbacks();
+ 
+-  // This filter chain options is only used for the downstream HTTP filter chains for now. So, try
+-  // to set valid initial route only when the downstream callbacks is available.
+-  FilterChainOptionsImpl options(downstream_callbacks.has_value() ? streamInfo().route() : nullptr);
++  FilterChainOptionsImpl options(streamInfo().route());
+ 
+   UpgradeResult upgrade = UpgradeResult::UpgradeUnneeded;
+ 
+diff --git source/common/http/utility.h source/common/http/utility.h
+index 1a867fca66..539b645680 100644
+--- source/common/http/utility.h
++++ source/common/http/utility.h
+@@ -600,8 +600,8 @@ const ConfigType* resolveMostSpecificPerFilterConfig(const Http::StreamFilterCal
+  *
+  * @param callbacks The stream filter callbacks to check for route configs.
+  *
+- * @return The all available per route config. The returned pointers are guaranteed to be non-null
+- * and their lifetime is the same as the matched route.
++ * @return all the available per route config in ascending order of specificity (i.e., route table
++ * first, then virtual host, then per route).
+  */
+ template <class ConfigType>
+ absl::InlinedVector<std::reference_wrapper<const ConfigType>, 4>
+diff --git source/common/upstream/upstream_impl.h source/common/upstream/upstream_impl.h
+index c713f8d3ca..cc8df73c64 100644
+--- source/common/upstream/upstream_impl.h
++++ source/common/upstream/upstream_impl.h
+@@ -1023,13 +1023,13 @@ public:
+ 
+   // Http::FilterChainFactory
+   bool createFilterChain(Http::FilterChainManager& manager,
+-                         const Http::FilterChainOptions&) const override {
++                         const Http::FilterChainOptions& options) const override {
+     if (http_filter_factories_.empty()) {
+       return false;
+     }
+ 
+-    Http::FilterChainUtility::createFilterChainForFactories(
+-        manager, Http::EmptyFilterChainOptions{}, http_filter_factories_);
++    Http::FilterChainUtility::createFilterChainForFactories(manager, options,
++                                                            http_filter_factories_);
+     return true;
+   }
+   bool createUpgradeFilterChain(absl::string_view, const UpgradeMap*, Http::FilterChainManager&,
+diff --git test/extensions/filters/http/header_mutation/header_mutation_integration_test.cc test/extensions/filters/http/header_mutation/header_mutation_integration_test.cc
+index 781c8d2d0c..32934d1414 100644
+--- test/extensions/filters/http/header_mutation/header_mutation_integration_test.cc
++++ test/extensions/filters/http/header_mutation/header_mutation_integration_test.cc
+@@ -28,6 +28,27 @@ RouteLevelFlag AllRoutesLevel = {PerRouteLevel | VirtualHostLevel | RouteTableLe
+ 
+ class HeaderMutationIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                       public HttpIntegrationTest {
++  std::string upstream_header_mutation_config_{R"EOF(
++  mutations:
++    request_mutations:
++    - append:
++        header:
++          key: "upstream-request-global-flag-header"
++          value: "upstream-request-global-flag-header-value"
++        append_action: APPEND_IF_EXISTS_OR_ADD
++    response_mutations:
++    - append:
++        header:
++          key: "upstream-global-flag-header"
++          value: "upstream-global-flag-header-value"
++        append_action: APPEND_IF_EXISTS_OR_ADD
++    - append:
++        header:
++          key: "request-method-in-upstream-filter"
++          value: "%REQ(:METHOD)%"
++        append_action: APPEND_IF_EXISTS_OR_ADD
++)EOF"};
++
+ public:
+   HeaderMutationIntegrationTest()
+       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()) {}
+@@ -112,8 +133,9 @@ public:
+           }
+         });
+   }
+-  void initializeFilterForSpecifityTest(bool most_specific_header_mutations_wins,
+-                                        bool disable_downstream_header_mutation = false) {
++
++  void initializeFilterForSpecificityTest(bool most_specific_header_mutations_wins,
++                                          bool disable_downstream_header_mutation = false) {
+     setUpstreamProtocol(FakeHttpConnection::Type::HTTP1);
+     // Add `downstream-header-mutation` filter to the filter chain.
+     envoy::extensions::filters::http::header_mutation::v3::HeaderMutation header_mutation;
+@@ -149,27 +171,7 @@ public:
+       setPerFilterConfigsWithSameKey("downstream");
+     } else {
+       // Add `upstream-header-mutation` filter.
+-      std::string header_mutation_config = R"EOF(
+-  mutations:
+-    request_mutations:
+-    - append:
+-        header:
+-          key: "upstream-request-global-flag-header"
+-          value: "upstream-request-global-flag-header-value"
+-        append_action: APPEND_IF_EXISTS_OR_ADD
+-    response_mutations:
+-    - append:
+-        header:
+-          key: "upstream-global-flag-header"
+-          value: "upstream-global-flag-header-value"
+-        append_action: APPEND_IF_EXISTS_OR_ADD
+-    - append:
+-        header:
+-          key: "request-method-in-upstream-filter"
+-          value: "%REQ(:METHOD)%"
+-        append_action: APPEND_IF_EXISTS_OR_ADD
+-)EOF";
+-      TestUtility::loadFromYaml(header_mutation_config, header_mutation);
++      TestUtility::loadFromYaml(upstream_header_mutation_config_, header_mutation);
+       envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter
+           http_mutation_filter;
+       http_mutation_filter.set_name("upstream-header-mutation");
+@@ -186,6 +188,80 @@ public:
+     HttpIntegrationTest::initialize();
+   }
+ 
++  // This function sets up the filter at various level of disable and enable test
++  // if "disabled" is false, that means we are testing enabling the filter at various level, so the
++  // filter is set up to be disabled by default. Then, enable at the specified "route_level" If
++  // "disabled" is true, that means we are testing disabling the filter at various level, so the
++  // filter is set up to be enabled by default. Then, disable at the specified "route_level"
++  void initializeUpstreamFilterForSpecificityEnableDisableTest(
++      bool most_specific_header_mutations_wins, RouteLevelFlag route_level, bool disabled = false) {
++    setUpstreamProtocol(FakeHttpConnection::Type::HTTP1);
++    envoy::extensions::filters::http::header_mutation::v3::HeaderMutation header_mutation;
++    TestUtility::loadFromYaml(upstream_header_mutation_config_, header_mutation);
++    envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter
++        http_mutation_filter;
++    http_mutation_filter.set_name("upstream-header-mutation");
++    if (!disabled) {
++      // We are testing enabled from various level, so disable the filter by default
++      http_mutation_filter.set_disabled(true);
++    }
++    if (most_specific_header_mutations_wins) {
++      header_mutation.set_most_specific_header_mutations_wins(true);
++    }
++    http_mutation_filter.mutable_typed_config()->PackFrom(header_mutation);
++    config_helper_.prependFilter(MessageUtil::getJsonStringFromMessageOrError(http_mutation_filter),
++                                 false);
++
++    config_helper_.addConfigModifier(
++        [route_level, disabled](
++            envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
++                hcm) {
++          auto* route = hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
++          route->mutable_match()->set_path("/default/route");
++
++          // Per route header mutation.
++          envoy::config::route::v3::FilterConfig per_route_filter_config;
++          if (route_level.test(RouteLevel::PerRoute)) {
++            per_route_filter_config.set_disabled(disabled);
++            PerRouteProtoConfig header_mutation;
++            per_route_filter_config.mutable_config()->PackFrom(header_mutation);
++            ProtobufWkt::Any per_route_config;
++            per_route_config.PackFrom(per_route_filter_config);
++            route->mutable_typed_per_filter_config()->insert(
++                {"upstream-header-mutation", per_route_config});
++          }
++
++          // Per virtual host header mutation.
++          envoy::config::route::v3::FilterConfig per_route_filter_config_vhost;
++          if (route_level.test(RouteLevel::VirtualHost)) {
++            per_route_filter_config_vhost.set_disabled(disabled);
++            PerRouteProtoConfig header_mutation_vhost;
++            per_route_filter_config_vhost.mutable_config()->PackFrom(header_mutation_vhost);
++            ProtobufWkt::Any per_route_config_vhost;
++            per_route_config_vhost.PackFrom(per_route_filter_config_vhost);
++
++            auto* vhost = hcm.mutable_route_config()->mutable_virtual_hosts(0);
++            vhost->mutable_typed_per_filter_config()->insert(
++                {"upstream-header-mutation", per_route_config_vhost});
++          }
++
++          // Per route table header mutation.
++          envoy::config::route::v3::FilterConfig per_route_filter_config_rt;
++          if (route_level.test(RouteLevel::RouteTable)) {
++            per_route_filter_config_rt.set_disabled(disabled);
++            PerRouteProtoConfig header_mutation_rt;
++            per_route_filter_config_rt.mutable_config()->PackFrom(header_mutation_rt);
++            ProtobufWkt::Any per_route_config_rt;
++            per_route_config_rt.PackFrom(per_route_filter_config_rt);
++
++            auto* route_table = hcm.mutable_route_config();
++            route_table->mutable_typed_per_filter_config()->insert(
++                {"upstream-header-mutation", per_route_config_rt});
++          }
++        });
++    HttpIntegrationTest::initialize();
++  }
++
+   void initializeFilter(RouteLevelFlag route_level) {
+     setUpstreamProtocol(FakeHttpConnection::Type::HTTP1);
+ 
+@@ -252,6 +328,31 @@ typed_config:
+           key: "request-method-in-upstream-filter"
+           value: "%REQ(:METHOD)%"
+         append_action: APPEND_IF_EXISTS_OR_ADD
++)EOF",
++                                 false);
++    config_helper_.prependFilter(R"EOF(
++name: upstream-header-mutation-disabled-by-default
++typed_config:
++  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
++  mutations:
++    request_mutations:
++    - append:
++        header:
++          key: "upstream-request-global-flag-header-disabled-by-default"
++          value: "upstream-request-global-flag-header-value-disabled-by-default"
++        append_action: APPEND_IF_EXISTS_OR_ADD
++    response_mutations:
++    - append:
++        header:
++          key: "upstream-global-flag-header-disabled-by-default"
++          value: "upstream-global-flag-header-value-disabled-by-default"
++        append_action: APPEND_IF_EXISTS_OR_ADD
++    - append:
++        header:
++          key: "request-method-in-upstream-filter-disabled-by-default"
++          value: "%REQ(:METHOD)%"
++        append_action: APPEND_IF_EXISTS_OR_ADD
++disabled: true
+ )EOF",
+                                  false);
+ 
+@@ -323,17 +424,18 @@ typed_config:
+               // Try enable the filter that is disabled by default.
+               route->mutable_typed_per_filter_config()->insert(
+                   {"downstream-header-mutation-disabled-by-default", per_route_config});
++              route->mutable_typed_per_filter_config()->insert(
++                  {"upstream-header-mutation-disabled-by-default", per_route_config});
+             }
+ 
+             {
+-              // Per route disable downstream header mutation.
++              // Per route disable downstream and upstream header mutation.
+               envoy::config::route::v3::FilterConfig filter_config;
+               filter_config.set_disabled(true);
+               ProtobufWkt::Any per_route_config;
+               per_route_config.PackFrom(filter_config);
+               another_route->mutable_typed_per_filter_config()->insert(
+                   {"downstream-header-mutation", per_route_config});
+-              // Try disable upstream header mutation but this is not supported and should not work.
+               another_route->mutable_typed_per_filter_config()->insert(
+                   {"upstream-header-mutation", per_route_config});
+             }
+@@ -423,6 +525,33 @@ typed_config:
+         });
+     HttpIntegrationTest::initialize();
+   }
++
++  void checkHeader(int line_num, IntegrationStreamDecoder& response, absl::string_view key,
++                   bool exists, absl::string_view value = "") {
++    SCOPED_TRACE(line_num);
++    auto headers = response.headers().get(Http::LowerCaseString(key));
++    if (exists) {
++      EXPECT_EQ(1, headers.size());
++      if (value.empty()) {
++        EXPECT_EQ(absl::StrCat(key, "-value"), headers[0]->value().getStringView());
++      } else {
++        EXPECT_EQ(value, headers[0]->value().getStringView());
++      }
++    } else {
++      EXPECT_EQ(0, headers.size());
++    }
++  };
++
++  void checkHeader(int line_num, FakeStream& request, absl::string_view key, bool exists) {
++    SCOPED_TRACE(line_num);
++    auto headers = request.headers().get(Http::LowerCaseString(key));
++    if (exists) {
++      EXPECT_EQ(1, headers.size());
++      EXPECT_EQ(absl::StrCat(key, "-value"), headers[0]->value().getStringView());
++    } else {
++      EXPECT_EQ(0, headers.size());
++    }
++  };
+ };
+ 
+ INSTANTIATE_TEST_SUITE_P(IpVersions, HeaderMutationIntegrationTest,
+@@ -522,6 +651,15 @@ TEST_P(HeaderMutationIntegrationTest, TestHeaderMutationAllLevelsApplied) {
+                 ->value()
+                 .getStringView());
+ 
++  // This header is injected by the "upstream-header-mutation-disabled-by-default" upstream filter
++  // which is disabled by default and re-enabled at route level at /default/route path
++  EXPECT_EQ(
++      "upstream-request-global-flag-header-value-disabled-by-default",
++      upstream_request_->headers()
++          .get(Http::LowerCaseString("upstream-request-global-flag-header-disabled-by-default"))[0]
++          ->value()
++          .getStringView());
++
+   upstream_request_->encodeHeaders(default_response_headers_, true);
+ 
+   ASSERT_TRUE(response->waitForEndStream());
+@@ -545,6 +683,19 @@ TEST_P(HeaderMutationIntegrationTest, TestHeaderMutationAllLevelsApplied) {
+                 ->value()
+                 .getStringView());
+ 
++  // These two headers are injected by the "upstream-header-mutation-disabled-by-default" upstream
++  // filter which is disabled by default and re-enabled at route level at /default/route path
++  EXPECT_EQ("upstream-global-flag-header-value-disabled-by-default",
++            response->headers()
++                .get(Http::LowerCaseString("upstream-global-flag-header-disabled-by-default"))[0]
++                ->value()
++                .getStringView());
++  EXPECT_EQ("GET", response->headers()
++                       .get(Http::LowerCaseString(
++                           "request-method-in-upstream-filter-disabled-by-default"))[0]
++                       ->value()
++                       .getStringView());
++
+   testResponseHeaderMutation(response.get(), AllRoutesLevel);
+ 
+   EXPECT_EQ("GET", response->headers()
+@@ -555,7 +706,7 @@ TEST_P(HeaderMutationIntegrationTest, TestHeaderMutationAllLevelsApplied) {
+ }
+ 
+ TEST_P(HeaderMutationIntegrationTest, TestHeaderMutationMostSpecificWins) {
+-  initializeFilterForSpecifityTest(/*most_specific_header_mutations_wins=*/true);
++  initializeFilterForSpecificityTest(/*most_specific_header_mutations_wins=*/true);
+ 
+   codec_client_ = makeHttpConnection(lookupPort("http"));
+   default_request_headers_.setPath("/default/route");
+@@ -583,7 +734,7 @@ TEST_P(HeaderMutationIntegrationTest, TestHeaderMutationMostSpecificWins) {
+ }
+ 
+ TEST_P(HeaderMutationIntegrationTest, TestHeaderMutationLeastSpecificWins) {
+-  initializeFilterForSpecifityTest(/*most_specific_header_mutations_wins=*/false);
++  initializeFilterForSpecificityTest(/*most_specific_header_mutations_wins=*/false);
+ 
+   codec_client_ = makeHttpConnection(lookupPort("http"));
+   default_request_headers_.setPath("/default/route");
+@@ -749,7 +900,7 @@ TEST_P(HeaderMutationIntegrationTest, TestHeaderMutationPerRouteTable) {
+   codec_client_->close();
+ }
+ 
+-TEST_P(HeaderMutationIntegrationTest, TestDisableDownstreamHeaderMutation) {
++TEST_P(HeaderMutationIntegrationTest, TestPerRouteDisableDownstreamAndUpstreamHeaderMutation) {
+   initializeFilter(AllRoutesLevel);
+   codec_client_ = makeHttpConnection(lookupPort("http"));
+   default_request_headers_.setPath("/disable/filter/route");
+@@ -765,11 +916,15 @@ TEST_P(HeaderMutationIntegrationTest, TestDisableDownstreamHeaderMutation) {
+                                               "default"))
+                    .size());
+ 
+-  EXPECT_EQ("upstream-request-global-flag-header-value",
+-            upstream_request_->headers()
+-                .get(Http::LowerCaseString("upstream-request-global-flag-header"))[0]
+-                ->value()
+-                .getStringView());
++  EXPECT_EQ(0, upstream_request_->headers()
++                   .get(Http::LowerCaseString("upstream-request-global-flag-header"))
++                   .size());
++
++  EXPECT_EQ(
++      0, upstream_request_->headers()
++             .get(Http::LowerCaseString("upstream-request-global-flag-header-disabled-by-default"))
++             .size());
++
+   EXPECT_EQ(upstream_request_->headers()
+                 .get(Http::LowerCaseString("downstream-request-per-route-flag-header"))
+                 .size(),
+@@ -795,21 +950,28 @@ TEST_P(HeaderMutationIntegrationTest, TestDisableDownstreamHeaderMutation) {
+       response->headers().get(Http::LowerCaseString("downstream-route-table-flag-header")).size(),
+       0);
+ 
+-  EXPECT_EQ("upstream-global-flag-header-value",
++  EXPECT_EQ(0,
++            response->headers().get(Http::LowerCaseString("upstream-global-flag-header")).size());
++
++  EXPECT_EQ(0, response->headers()
++                   .get(Http::LowerCaseString("upstream-global-flag-header-disabled-by-default"))
++                   .size());
++
++  EXPECT_EQ(0,
+             response->headers()
+-                .get(Http::LowerCaseString("upstream-global-flag-header"))[0]
+-                ->value()
+-                .getStringView());
+-  EXPECT_EQ("GET", response->headers()
+-                       .get(Http::LowerCaseString("request-method-in-upstream-filter"))[0]
+-                       ->value()
+-                       .getStringView());
++                .get(Http::LowerCaseString("request-method-in-upstream-filter-disabled-by-default"))
++                .size());
++
++  EXPECT_EQ(
++      0,
++      response->headers().get(Http::LowerCaseString("request-method-in-upstream-filter")).size());
++
+   codec_client_->close();
+ }
+ 
+ TEST_P(HeaderMutationIntegrationTest, TestDisableDownstreamHeaderMutationWithSpecific) {
+-  initializeFilterForSpecifityTest(/*most_specific_header_mutations_wins=*/false,
+-                                   /*disable_downstream_header_mutation=*/true);
++  initializeFilterForSpecificityTest(/*most_specific_header_mutations_wins=*/false,
++                                     /*disable_downstream_header_mutation=*/true);
+ 
+   codec_client_ = makeHttpConnection(lookupPort("http"));
+   default_request_headers_.setPath("/disable/filter/route");
+@@ -820,6 +982,7 @@ TEST_P(HeaderMutationIntegrationTest, TestDisableDownstreamHeaderMutationWithSpe
+                    .get(Http::LowerCaseString("downstream-request-global-flag-header"))
+                    .size());
+ 
++  // This header was never set in the config
+   EXPECT_EQ(0, upstream_request_->headers()
+                    .get(Http::LowerCaseString("downstream-request-global-flag-header-disabled-by-"
+                                               "default"))
+@@ -830,6 +993,8 @@ TEST_P(HeaderMutationIntegrationTest, TestDisableDownstreamHeaderMutationWithSpe
+                 .get(Http::LowerCaseString("upstream-request-global-flag-header"))[0]
+                 ->value()
+                 .getStringView());
++
++  // This header was never set in the config
+   EXPECT_EQ(upstream_request_->headers()
+                 .get(Http::LowerCaseString("downstream-request-per-route-flag-header"))
+                 .size(),
+@@ -853,9 +1018,285 @@ TEST_P(HeaderMutationIntegrationTest, TestDisableDownstreamHeaderMutationWithSpe
+                        .get(Http::LowerCaseString("request-method-in-upstream-filter"))[0]
+                        ->value()
+                        .getStringView());
++  EXPECT_EQ(0, response->headers().get(Http::LowerCaseString("upstream-flag-header")).size());
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestDisableUpstreamHeaderMutationAtRouteTableLevelMostSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(true, RouteTableLevel, true);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", false);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", false);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", false);
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestDisableUpstreamHeaderMutationAtRouteTableLevelLeastSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(false, RouteTableLevel, true);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", false);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", false);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", false);
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestDisableUpstreamHeaderMutationAtVHostLevelMostSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(true, VirtualHostLevel, true);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", false);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", false);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", false);
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestDisableUpstreamHeaderMutationAtVHostLevelLeastSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(false, VirtualHostLevel, true);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", false);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", false);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", false);
++
+   codec_client_->close();
+ }
+ 
++TEST_P(HeaderMutationIntegrationTest,
++       TestDisableUpstreamHeaderMutationAtPerRouteLevelMostSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(true, PerRouteLevel, true);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", false);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", false);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", false);
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestDisableUpstreamHeaderMutationAtPerRouteLevelLeastSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(false, PerRouteLevel, true);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", false);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", false);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", false);
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestEnableUpstreamHeaderMutationAtPerRouteLevelLeastSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(false, PerRouteLevel);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", true);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", true);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", true, "GET");
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestEnableUpstreamHeaderMutationAtPerRouteLevelMostSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(true, PerRouteLevel);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", true);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", true);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", true, "GET");
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestEnableUpstreamHeaderMutationAtVHostLevelLeastSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(false, VirtualHostLevel);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", true);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", true);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", true, "GET");
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestEnableUpstreamHeaderMutationAtVHostLevelMostSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(true, VirtualHostLevel);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", true);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", true);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", true, "GET");
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestEnableUpstreamHeaderMutationAtRouteTableLevelLeastSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(false, RouteTableLevel);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", true);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", true);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", true, "GET");
++
++  codec_client_->close();
++}
++
++TEST_P(HeaderMutationIntegrationTest,
++       TestEnableUpstreamHeaderMutationAtRouteTableLevelMostSpecificWins) {
++  initializeUpstreamFilterForSpecificityEnableDisableTest(true, RouteTableLevel);
++
++  codec_client_ = makeHttpConnection(lookupPort("http"));
++  default_request_headers_.setPath("/default/route");
++  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
++  waitForNextUpstreamRequest();
++
++  checkHeader(__LINE__, *upstream_request_, "upstream-request-global-flag-header", true);
++
++  upstream_request_->encodeHeaders(default_response_headers_, true);
++
++  ASSERT_TRUE(response->waitForEndStream());
++  EXPECT_TRUE(response->complete());
++  EXPECT_EQ("200", response->headers().getStatusValue());
++
++  checkHeader(__LINE__, *response, "upstream-global-flag-header", true);
++  checkHeader(__LINE__, *response, "request-method-in-upstream-filter", true, "GET");
++
++  codec_client_->close();
++}
+ } // namespace
+ } // namespace HeaderMutation
+ } // namespace HttpFilters
+diff --git test/integration/upstream_http_filter_integration_test.cc test/integration/upstream_http_filter_integration_test.cc
+index 375648d1f1..e74ee35b3a 100644
+--- test/integration/upstream_http_filter_integration_test.cc
++++ test/integration/upstream_http_filter_integration_test.cc
+@@ -74,12 +74,15 @@ public:
+   }
+ 
+   const HttpFilterProto getAddHeaderFilterConfig(const std::string& name, const std::string& key,
+-                                                 const std::string& value) {
++                                                 const std::string& value, bool disabled = false) {
+     HttpFilterProto filter_config;
+     filter_config.set_name(name);
+     auto configuration = test::integration::filters::AddHeaderFilterConfig();
+     configuration.set_header_key(key);
+     configuration.set_header_value(value);
++    if (disabled) {
++      filter_config.set_disabled(true);
++    }
+     filter_config.mutable_typed_config()->PackFrom(configuration);
+     return filter_config;
+   }
+@@ -177,6 +180,26 @@ TEST_P(StaticRouterOrClusterFiltersIntegrationTest,
+   EXPECT_THAT(*headers, HeaderValueOf("x-test-cluster", "bb"));
+ }
+ 
++TEST_P(StaticRouterOrClusterFiltersIntegrationTest, ClusterUpstreamFiltersDisabled) {
++  addStaticRouterFilter(
++      getAddHeaderFilterConfig("envoy.test.add_header_upstream", "x-test-router", "aa", true));
++  addCodecRouterFilter();
++  initialize();
++
++  auto headers = sendRequestAndGetHeaders();
++  EXPECT_THAT(*headers, Not(HeaderValueOf("x-test-router", "aa")));
++}
++
++TEST_P(StaticRouterOrClusterFiltersIntegrationTest, RouterUpstreamFiltersDisabled) {
++  addStaticClusterFilter(
++      getAddHeaderFilterConfig("envoy.test.add_header_upstream", "x-test-cluster", "bb", true));
++  addCodecClusterFilter();
++  initialize();
++
++  auto headers = sendRequestAndGetHeaders();
++  EXPECT_THAT(*headers, Not(HeaderValueOf("x-test-cluster", "bb")));
++}
++
+ TEST_P(StaticRouterOrClusterFiltersIntegrationTest,
+        AsyncClientUsesClusterFiltersButNotRouterFilters) {
+   // This filter intercepts the downstream request and reissues it via AsyncClient,
+-- 
+2.49.0
+

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -69,6 +69,7 @@ def envoy_gloo_dependencies():
     _repository_impl("envoy", patches=[
         # revert upstream's cache filter from using a separate HttpAsyncClient
         "@envoy_gloo//bazel/foreign_cc:002-revert-cache_filter-separate-upstream.patch",
+        "@envoy_gloo//bazel/foreign_cc:004-fixed-upstream-filter-disabled-by-default.patch",
     ])
     _repository_impl("json", build_file = "@envoy_gloo//bazel/external:json.BUILD")
     _repository_impl("inja", build_file = "@envoy_gloo//bazel/external:inja.BUILD")

--- a/changelog/v1.34.1-patch3/main.yaml
+++ b/changelog/v1.34.1-patch3/main.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7291
+    resolvesIssue: false
+    description: >-
+      This patch fixed upstream issue: https://github.com/envoyproxy/envoy/issues/39587 which is needed by AI bedrock support


### PR DESCRIPTION
This patch brings in the change from this upstream PR which is still pending review: https://github.com/envoyproxy/envoy/pull/39878

