### PR TITLE
[AI] bedrock custom path override support

### DIFF
--- a/changelog/v1.34.1-patch4/bedrock-custom-pathoverride.yaml
+++ b/changelog/v1.34.1-patch4/bedrock-custom-pathoverride.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/8315
+    resolvesIssue: false
+    description: >-
+      [AI] bedrock custom path override support

--- a/source/extensions/filters/http/transformation/ai_transformer.cc
+++ b/source/extensions/filters/http/transformation/ai_transformer.cc
@@ -607,14 +607,16 @@ std::tuple<bool, bool> AiTransformer::transformHeaders(
 
   } else if (provider == AiTransformerConstants::get().PROVIDER_BEDROCK) {
     ASSERT(!model.empty(), "Bedrock: required model setting is missing!");
-    path = replaceModelInPath(
-        lookupEndpointMetadata(endpoint_metadata, "base_path"), model);
-    if (enable_chat_streaming_) {
-      absl::StrAppend(&path, AiTransformerConstants::get().BEDROCK_CONVERSE_STREAM);
-    } else {
-      absl::StrAppend(&path, AiTransformerConstants::get().BEDROCK_CONVERSE);
+    path = lookupEndpointMetadata(endpoint_metadata, "path");
+    if (path.empty()) {
+      path = replaceModelInPath(
+          lookupEndpointMetadata(endpoint_metadata, "base_path"), model);
+      if (enable_chat_streaming_) {
+        absl::StrAppend(&path, AiTransformerConstants::get().BEDROCK_CONVERSE_STREAM);
+      } else {
+        absl::StrAppend(&path, AiTransformerConstants::get().BEDROCK_CONVERSE);
+      }
     }
-
   } else if (provider == AiTransformerConstants::get().PROVIDER_VERTEXAI) {
     ASSERT(!model.empty(), "VertexAI: required model setting is missing!");
     path = replaceModelInPath(


### PR DESCRIPTION
Add ability to override the path for bedrock upstream. 
If there is a fullpath override, the control plane will set the "path" metadata. If not, it will set the "base_path" metadata. 