### PR TITLE
Support OpenAI realtime API and websocket passthrough in Transformation filter

### DIFF
--- a/changelog/v1.35.0-patch2/websocket-realtime-api-transformation-passthrough.yaml
+++ b/changelog/v1.35.0-patch2/websocket-realtime-api-transformation-passthrough.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/8530
+    resolvesIssue: false
+    description: >-
+      Support OpenAI realtime API and websocket passthrough in Transformation filter

--- a/source/extensions/filters/http/transformation/ai_transformer.cc
+++ b/source/extensions/filters/http/transformation/ai_transformer.cc
@@ -104,10 +104,17 @@ std::string replaceModelInPath(std::string_view original_path,
  * @return const Regex::CompiledGoogleReMatcher&
  */
 const Regex::CompiledGoogleReMatcher &openAiPlatformApiRegex() {
+  // This list of OpenAI Platform API endpoints can be found here:
+  // https://platform.openai.com/docs/api-reference/ under the "Platform APIs" section
+  // These are endpoints that we don't apply any AI specific features to, so we go into
+  // "bypass mode" and we don't modify the URL or inject anything to the request/response
+  // body.
+  // Technically, the "realtime" API is not part of the Platform API but we are adding it
+  // here for convenience as the behavior is the same
   CONSTRUCT_ON_FIRST_USE(Regex::CompiledGoogleReMatcherNoSafetyChecks,
                          ".*(/v[0-9]+[a-z]*)(/"
                          "(audio|embeddings|fine_tuning|batches|files|uploads|"
-                         "images|models|moderations).*)");
+                         "images|models|moderations|realtime).*)");
 }
 
 /**

--- a/source/extensions/filters/http/transformation/transformation_filter.h
+++ b/source/extensions/filters/http/transformation/transformation_filter.h
@@ -120,6 +120,7 @@ private:
   std::string error_messgae_;
   bool should_clear_cache_{};
   bool destroyed_{};
+  bool is_websocket_upgrade_request_{false};
 
   FilterConfigSharedPtr filter_config_;
 };


### PR DESCRIPTION
Changes:
- Added bypass detection for the OpenAI realtime API in AI Transformer
- Auto body PassThrough in Transformation filter when the request is websocket upgrade request

Consideration:
We recently learnt that websocket does not work with Transformation in general with it's default config. We have to add `passThrough: {}` for websocket to work or the request will hang there forever. 
OpenAI realtime API also uses websocket and the AI Transformer follows most of the Transformation behavior; however, in this case, we need to dynamically switch on body passthrough instead of setting it in the configuration. While there is a passthrough_body() in the Transformer interface, we cannot change that because:
1. The Transformer is created once when the filter is created, per request state cannot be stored inside the transformer.
2. All the functions are `const`, while I can hack it with `mutable` but that's not ideal. 

So, decided to do the auto body passthrough for all websocket upgrade requests in the root transformation filter where per request state can be stored. websocket upgrade request should never have a body. With this change:
1. user no longer need to remember to add `passthrough: {}` for websocket to work.
2. user may not be able to add `passthrough: {}` if they need to do body transformation. 

@yuval-k please double check my logic here. 